### PR TITLE
Fix appendEncryptionKeys logic with patient-user object

### DIFF
--- a/icc-x-api/icc-accesslog-x-api.ts
+++ b/icc-x-api/icc-accesslog-x-api.ts
@@ -160,7 +160,7 @@ export class IccAccesslogXApi extends IccAccesslogApi {
         (delegateId) =>
           (promise = promise.then((accessLog) =>
             this.crypto.appendEncryptionKeys(accessLog, dataOwnerId!, delegateId, eks.secretId).then((extraEks) => {
-              return _.extend(accessLog, {
+              return _.extend(extraEks.modifiedObject, {
                 encryptionKeys: extraEks.encryptionKeys,
               })
             })

--- a/icc-x-api/icc-calendar-item-x-api.ts
+++ b/icc-x-api/icc-calendar-item-x-api.ts
@@ -210,7 +210,7 @@ export class IccCalendarItemXApi extends IccCalendarItemApi {
         (delegateId) =>
           (promise = promise.then((item) =>
             this.crypto.appendEncryptionKeys(item, dataOwnerId!, delegateId, eks.secretId).then((extraEks) => {
-              return _.extend(item, {
+              return _.extend(extraEks.modifiedObject, {
                 encryptionKeys: extraEks.encryptionKeys,
               })
             })

--- a/icc-x-api/icc-contact-x-api.ts
+++ b/icc-x-api/icc-contact-x-api.ts
@@ -133,7 +133,7 @@ export class IccContactXApi extends IccContactApi {
             this.crypto
               .appendEncryptionKeys(contact, dataOwnerId!, delegateId, eks.secretId)
               .then((extraEks) => {
-                return _.extend(contact, {
+                return _.extend(extraEks.modifiedObject, {
                   encryptionKeys: extraEks.encryptionKeys,
                 })
               })

--- a/icc-x-api/icc-document-x-api.ts
+++ b/icc-x-api/icc-document-x-api.ts
@@ -591,7 +591,7 @@ export class IccDocumentXApi extends IccDocumentApi {
         (delegateId) =>
           (promise = promise.then((document) =>
             this.crypto.appendEncryptionKeys(document, dataOwnerId!, delegateId, eks.secretId).then((extraEks) => {
-              return _.extend(document, {
+              return _.extend(extraEks.modifiedObject, {
                 encryptionKeys: extraEks.encryptionKeys,
               })
             })

--- a/icc-x-api/icc-form-x-api.ts
+++ b/icc-x-api/icc-form-x-api.ts
@@ -59,7 +59,7 @@ export class IccFormXApi extends IccFormApi {
         (delegateId) =>
           (promise = promise.then((contact) =>
             this.crypto.appendEncryptionKeys(contact, dataOwnerId!, delegateId, eks.secretId).then((extraEks) => {
-              return _.extend(contact, {
+              return _.extend(extraEks.modifiedObject, {
                 encryptionKeys: extraEks.encryptionKeys,
               })
             })

--- a/icc-x-api/icc-helement-x-api.ts
+++ b/icc-x-api/icc-helement-x-api.ts
@@ -318,7 +318,7 @@ export class IccHelementXApi extends IccHelementApi {
             this.crypto
               .appendEncryptionKeys(healthElement, dataOwnerId!, delegateId, eks.secretId)
               .then((extraEks) => {
-                return _.extend(healthElement, {
+                return _.extend(extraEks.modifiedObject, {
                   encryptionKeys: extraEks.encryptionKeys,
                 })
               })

--- a/icc-x-api/icc-invoice-x-api.ts
+++ b/icc-x-api/icc-invoice-x-api.ts
@@ -63,7 +63,7 @@ export class IccInvoiceXApi extends IccInvoiceApi {
         (delegateId) =>
           (promise = promise.then((invoice) =>
             this.crypto.appendEncryptionKeys(invoice, dataOwnerId!, delegateId, eks.secretId).then((extraEks) => {
-              return _.extend(invoice, {
+              return _.extend(extraEks.modifiedObject, {
                 encryptionKeys: extraEks.encryptionKeys,
               })
             })

--- a/icc-x-api/icc-maintenance-task-x-api.ts
+++ b/icc-x-api/icc-maintenance-task-x-api.ts
@@ -86,7 +86,7 @@ export class IccMaintenanceTaskXApi extends IccMaintenanceTaskApi {
             this.crypto
               .appendEncryptionKeys(patient, dataOwnerId!, delegateId, eks.secretId)
               .then((extraEks) => {
-                return _.extend(patient, {
+                return _.extend(extraEks.modifiedObject, {
                   encryptionKeys: extraEks.encryptionKeys,
                 })
               })

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -625,7 +625,7 @@ export class IccPatientXApi extends IccPatientApi {
             this.crypto
               .appendEncryptionKeys(patient, dataOwnerId!, delegateId, eks.secretId)
               .then((extraEks) => {
-                return _.extend(patient, {
+                return _.extend(extraEks.modifiedObject, {
                   encryptionKeys: extraEks.encryptionKeys,
                 })
               })

--- a/icc-x-api/icc-receipt-x-api.ts
+++ b/icc-x-api/icc-receipt-x-api.ts
@@ -55,7 +55,7 @@ export class IccReceiptXApi extends IccReceiptApi {
         (delegateId) =>
           (promise = promise.then((receipt) =>
             this.crypto.appendEncryptionKeys(receipt, dataOwnerId, delegateId, eks.secretId).then((extraEks) => {
-              return _.extend(receipt, {
+              return _.extend(extraEks.modifiedObject, {
                 encryptionKeys: extraEks.encryptionKeys,
               })
             })

--- a/test/icc-x-api/crypto/full-crypto-test.ts
+++ b/test/icc-x-api/crypto/full-crypto-test.ts
@@ -467,9 +467,10 @@ describe('Full battery of tests on crypto and keys', async function () {
           const parent = f[0] !== 'Patient' ? await api.patientApi.getPatientWithUser(u, `${u.id}-Patient`) : undefined
           const record = await entities[f[0] as TestedEntity](api, `${u.id}-${f[0]}`, u, parent)
           const entity = await facade.create(api, record)
+          const retrieved = await facade.get(api, entity.id)
 
           expect(entity.id).to.be.not.null
-          expect(entity.rev).to.be.not.null
+          expect(entity.rev).to.equal(retrieved.rev)
           expect(await facade.isDecrypted(entity)).to.equal(true)
         })
         it(`Create ${f[0]} as delegate with delegation for ${uType} with ${uId}`, async () => {
@@ -486,6 +487,7 @@ describe('Full battery of tests on crypto and keys', async function () {
             (u.patientId ?? u.healthcarePartyId ?? u.deviceId)!,
           ])
           const entity = await facade.create(api, record)
+          const retrieved = await facade.get(api, entity.id)
           const hcp = await api.healthcarePartyApi.getCurrentHealthcareParty()
 
           const shareKeys = hcp.aesExchangeKeys[hcp.publicKey][dataOwnerId]
@@ -496,7 +498,7 @@ describe('Full battery of tests on crypto and keys', async function () {
           await api.healthcarePartyApi.modifyHealthcareParty(hcp)
 
           expect(entity.id).to.be.not.null
-          expect(entity.rev).to.be.not.null
+          expect(entity.rev).to.equal(retrieved.rev)
           expect(await facade.isDecrypted(entity)).to.equal(true)
         })
         it(`Read ${f[0]} as the initial ${uType} with ${uId}`, async () => {
@@ -539,6 +541,8 @@ describe('Full battery of tests on crypto and keys', async function () {
 
               const parent = f[0] !== 'Patient' ? await api.patientApi.getPatientWithUser(u, `${u.id}-Patient`) : undefined
               const entity = await facade.share(api, parent, await facade.get(api, `${u.id}-${f[0]}`), delegateDoId)
+              const retrieved = await facade.get(api, entity.id)
+              expect(entity.rev).to.equal(retrieved.rev)
               expect(Object.keys(entity.delegations)).to.contain(delegateDoId)
 
               const delApi = await getApiAndAddPrivateKeysForUser(du!)


### PR DESCRIPTION
`appendEncryptionKeys` in the `icc-crypto-x-api` should return the updated modified object like `extendedDelegationsAndCryptedForeignKeys` to support cases where the object is the same as the data owner.
There were no problems with the way `appendEncryptionKeys` was currently used in the sdk, but the fix is necessary to fix an issue with the medtech sdk.