### PR TITLE
Renamed deleteItem to removeItem

### DIFF
--- a/icc-x-api/icc-crypto-x-api.ts
+++ b/icc-x-api/icc-crypto-x-api.ts
@@ -1648,10 +1648,6 @@ export class IccCryptoXApi {
    * @returns {Object} it is in JWK - not imported
    */
   async loadKeyPairNotImported(id: string, publicKeyFingerPrint?: string): Promise<{ publicKey: JsonWebKey; privateKey: JsonWebKey }> {
-    if (typeof Storage === 'undefined') {
-      console.log('Your browser does not support HTML5 Browser Local Storage !')
-      throw 'Your browser does not support HTML5 Browser Local Storage !'
-    }
     //TODO decryption
     const item = publicKeyFingerPrint
       ? (await this._keyStorage.getKeypair(this.rsaLocalStoreIdPrefix + id + '.' + publicKeyFingerPrint.slice(-32))) ??

--- a/icc-x-api/icc-crypto-x-api.ts
+++ b/icc-x-api/icc-crypto-x-api.ts
@@ -1501,13 +1501,13 @@ export class IccCryptoXApi {
   }
 
   // noinspection JSUnusedGlobalSymbols
-  saveKeychainValidityDateInBrowserLocalStorage(id: string, date: string) {
+  async saveKeychainValidityDateInBrowserLocalStorage(id: string, date: string) {
     if (!id) return
 
     if (!date) {
-      this._storage.deleteItem(this.keychainValidityDateLocalStoreIdPrefix + id)
+      await this._storage.removeItem(this.keychainValidityDateLocalStoreIdPrefix + id)
     } else {
-      this._storage.setItem(this.keychainValidityDateLocalStoreIdPrefix + id, date)
+      await this._storage.setItem(this.keychainValidityDateLocalStoreIdPrefix + id, date)
     }
   }
 

--- a/icc-x-api/storage/KeyStorageImpl.ts
+++ b/icc-x-api/storage/KeyStorageImpl.ts
@@ -8,8 +8,8 @@ export class KeyStorageImpl implements KeyStorageFacade {
     this._storage = storage
   }
 
-  deleteKeypair(key: string): Promise<void> {
-    return this._storage.deleteItem(key)
+  async deleteKeypair(key: string): Promise<void> {
+    return await this._storage.removeItem(key)
   }
 
   async getKeypair(key: string): Promise<{ publicKey: JsonWebKey; privateKey: JsonWebKey } | undefined> {

--- a/icc-x-api/storage/LocalStorageImpl.ts
+++ b/icc-x-api/storage/LocalStorageImpl.ts
@@ -4,7 +4,7 @@ export class LocalStorageImpl implements StorageFacade<string> {
   async getItem(key: string): Promise<string | undefined> {
     if (typeof Storage === 'undefined') {
       console.error('Your browser does not support HTML5 Browser Local Storage !')
-      throw 'Your browser does not support HTML5 Browser Local Storage !'
+      throw new Error('Your browser does not support HTML5 Browser Local Storage !')
     }
     return localStorage.getItem(key) ?? undefined
   }
@@ -12,7 +12,7 @@ export class LocalStorageImpl implements StorageFacade<string> {
   async removeItem(key: string): Promise<void> {
     if (typeof Storage === 'undefined') {
       console.error('Your browser does not support HTML5 Browser Local Storage !')
-      throw 'Your browser does not support HTML5 Browser Local Storage !'
+      throw new Error('Your browser does not support HTML5 Browser Local Storage !')
     }
     return localStorage.removeItem(key)
   }
@@ -20,7 +20,7 @@ export class LocalStorageImpl implements StorageFacade<string> {
   async setItem(key: string, valueToStore: string): Promise<void> {
     if (typeof Storage === 'undefined') {
       console.error('Your browser does not support HTML5 Browser Local Storage !')
-      throw 'Your browser does not support HTML5 Browser Local Storage !'
+      throw new Error('Your browser does not support HTML5 Browser Local Storage !')
     }
     return localStorage.setItem(key, valueToStore)
   }

--- a/icc-x-api/storage/LocalStorageImpl.ts
+++ b/icc-x-api/storage/LocalStorageImpl.ts
@@ -2,10 +2,18 @@ import { StorageFacade } from './StorageFacade'
 
 export class LocalStorageImpl implements StorageFacade<string> {
   async getItem(key: string): Promise<string | undefined> {
+    if (typeof Storage === 'undefined') {
+      console.error('Your browser does not support HTML5 Browser Local Storage !')
+      throw 'Your browser does not support HTML5 Browser Local Storage !'
+    }
     return localStorage.getItem(key) ?? undefined
   }
 
   async removeItem(key: string): Promise<void> {
+    if (typeof Storage === 'undefined') {
+      console.error('Your browser does not support HTML5 Browser Local Storage !')
+      throw 'Your browser does not support HTML5 Browser Local Storage !'
+    }
     return localStorage.removeItem(key)
   }
 

--- a/icc-x-api/storage/LocalStorageImpl.ts
+++ b/icc-x-api/storage/LocalStorageImpl.ts
@@ -5,7 +5,7 @@ export class LocalStorageImpl implements StorageFacade<string> {
     return localStorage.getItem(key) ?? undefined
   }
 
-  async deleteItem(key: string): Promise<void> {
+  async removeItem(key: string): Promise<void> {
     return localStorage.removeItem(key)
   }
 

--- a/icc-x-api/storage/StorageFacade.ts
+++ b/icc-x-api/storage/StorageFacade.ts
@@ -17,5 +17,5 @@ export interface StorageFacade<T> {
    * Removes the item with the given key from the storage.
    * @param key The key of the item to remove.
    */
-  deleteItem(key: string): Promise<void>
+  removeItem(key: string): Promise<void>
 }

--- a/test/icc-x-api/storage/storage.ts
+++ b/test/icc-x-api/storage/storage.ts
@@ -35,7 +35,7 @@ describe('Test LocalStorageFacade abstraction', () => {
     const value = 'value'
     await testStorage.setItem(key, value)
     expect(await testStorage.getItem(key)).to.eq(value)
-    await testStorage.deleteItem(key)
+    await testStorage.removeItem(key)
     expect(await testStorage.getItem(key)).to.be.undefined
   })
 })


### PR DESCRIPTION
According to received feedback, I renamed `StorageFacade#deleteItem` to `StorageFacade#removeItem`. This way, LocalStorage abstraction library like React-Native AsyncStorage can be used directly without any other manipulation.