### PR TITLE
Automation of release management

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -4,7 +4,6 @@ changelog:
       - ignore-for-release
       - SemVer.Major
       - SemVer.Minor
-      - SemVer.Patch
     authors:
       - iCure
       - octocat
@@ -25,6 +24,6 @@ changelog:
     - title: Documentation 📄
       labels:
         - documentation
-    - title: Other Changes
+    - title: Other Changes ⚙️
       labels:
         - '*'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,30 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - SemVer.Major
+      - SemVer.Minor
+      - SemVer.Patch
+    authors:
+      - iCure
+      - octocat
+      - dependabot
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - breaking-change
+    - title: New Features 🎉
+      labels:
+        - enhancement
+    - title: Patches 🩹
+      labels:
+        - patch
+    - title: Hotfix 🚨
+      labels:
+        - hotfix
+    - title: Documentation 📄
+      labels:
+        - documentation
+    - title: Other Changes
+      labels:
+        - '*'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        env:
+          REPO: icure/icure-typescript-sdk
       - run: git config --global user.email "dev@icure.com"
       - run: git config --global user.name "iCure"
       - name: Setup Node ⚙️
@@ -58,12 +60,16 @@ jobs:
         run: |
           latestTag="$(git describe --abbrev=0 --tags)"
           currentBranch="$(git branch --show-current)"
+          lastReleaseDate="$(gh api -H "Accept: application/vnd.github+json" /repos/$REPO/releases/latest | jq '.published_at' -r)"
+          searchResult="$(gh api -X GET -H 'Accept: application/vnd.github.v3+json' search/issues -f  -f q="repo:$REPO is:pull-request is:merged merged:>$lastReleaseDate" | jq .)"
+          prNotes="$(gh api -X GET -H 'Accept: application/vnd.github.v3+json' search/issues -f q="repo:$REPO is:pull-request is:merged merged:>lastReleaseDate" -f per_page=100 | jq '.items[] | select(.body != null) | "## \(.title)\n\n\(.body//"")\n----"' -r)"
 
           echo 'LATEST_TAG='$latestTag >> $GITHUB_ENV
           echo 'CURRENT_BRANCH='$currentBranch >> $GITHUB_ENV
+          echo 'PR_NOTES='$prNotes >> $GITHUB_ENV
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create a release 📝
-        run: gh api --method POST /repos/icure/icure-typescript-sdk/releases -f tag_name="$LATEST_TAG" -f target_commitish="$CURRENT_BRANCH" -f name="$LATEST_TAG" -F draft=false -F generate_release_notes=true -F prerelease=false
+        run: gh api --method POST /repos/$REPO/releases -f tag_name="$LATEST_TAG" -f target_commitish="$CURRENT_BRANCH" -f name="$LATEST_TAG" -F draft=false -F generate_release_notes=true -F prerelease=false body="$PR_NOTES"
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,8 +16,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        env:
-          REPO: icure/icure-typescript-sdk
       - run: git config --global user.email "dev@icure.com"
       - run: git config --global user.name "iCure"
       - name: Setup Node ⚙️
@@ -53,6 +51,8 @@ jobs:
     name: Release note
     needs: [if_merged]
     runs-on: ubuntu-latest
+    env:
+      REPO: icure/icure-typescript-sdk
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -61,8 +61,7 @@ jobs:
           latestTag="$(git describe --abbrev=0 --tags)"
           currentBranch="$(git branch --show-current)"
           lastReleaseDate="$(gh api -H "Accept: application/vnd.github+json" /repos/$REPO/releases/latest | jq '.published_at' -r)"
-          searchResult="$(gh api -X GET -H 'Accept: application/vnd.github.v3+json' search/issues -f  -f q="repo:$REPO is:pull-request is:merged merged:>$lastReleaseDate" | jq .)"
-          prNotes="$(gh api -X GET -H 'Accept: application/vnd.github.v3+json' search/issues -f q="repo:$REPO is:pull-request is:merged merged:>lastReleaseDate" -f per_page=100 | jq '.items[] | select(.body != null) | "## \(.title)\n\n\(.body//"")\n----"' -r)"
+          prNotes="$(gh api -X GET -H 'Accept: application/vnd.github.v3+json' search/issues -f q="repo:$REPO is:pull-request is:merged merged:>$lastReleaseDate" -f per_page=100 | jq '.items[] | select(.body != null) | "## \(.title)\r\n\(.body//"")\r\n----"' -r)"
 
           echo 'LATEST_TAG='$latestTag >> $GITHUB_ENV
           echo 'CURRENT_BRANCH='$currentBranch >> $GITHUB_ENV
@@ -70,6 +69,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Create a release 📝
-        run: gh api --method POST /repos/$REPO/releases -f tag_name="$LATEST_TAG" -f target_commitish="$CURRENT_BRANCH" -f name="$LATEST_TAG" -F draft=false -F generate_release_notes=true -F prerelease=false body="$PR_NOTES"
+        run: gh api --method POST /repos/$REPO/releases -f tag_name="$LATEST_TAG" -f target_commitish="$CURRENT_BRANCH" -f name="$LATEST_TAG" -F draft=false -F generate_release_notes=true -F prerelease=false -f body="$PR_NOTES"
         env:
           GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
 
           echo 'LATEST_TAG='$latestTag >> $GITHUB_ENV
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
       - name: Publish package on NPM 📦
         run: yarn run prepare && cd dist && yarn run publish --no-git-tag-version --new-version $LATEST_TAG && cd ..
         env:
@@ -67,7 +67,7 @@ jobs:
           echo 'CURRENT_BRANCH='$currentBranch >> $GITHUB_ENV
           echo 'PR_NOTES='$prNotes >> $GITHUB_ENV
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
       - name: Create a release 📝
         run: gh api --method POST /repos/$REPO/releases -f tag_name="$LATEST_TAG" -f target_commitish="$CURRENT_BRANCH" -f name="$LATEST_TAG" -F draft=false -F generate_release_notes=true -F prerelease=false -f body="$PR_NOTES"
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,69 @@
+name: Release management
+
+on:
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - 'main'
+      - 'support/**'
+
+jobs:
+  if_merged:
+    name: Build & Publish to NPM
+    if: github.event.pull_request.merged == true && (contains(github.event.pull_request.labels.*.name, 'SemVer.Major') || contains(github.event.pull_request.labels.*.name, 'SemVer.Minor') || contains(github.event.pull_request.labels.*.name, 'SemVer.Patch'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - run: git config --global user.email "dev@icure.com"
+      - run: git config --global user.name "iCure"
+      - name: Setup Node ⚙️
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.x'
+          registry-url: 'https://registry.npmjs.org'
+      - name: Install dependencies and build 🔧
+        run: yarn install && yarn run build
+      - name: Creation new version (Major) 🏷️
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'SemVer.Major') }}
+        run: yarn version --major
+      - name: Creation new version (Minor) 🏷️
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'SemVer.Minor') }}
+        run: yarn version --minor
+      - name: Creation new version (Patch) 🏷️
+        if: ${{ contains(github.event.pull_request.labels.*.name, 'SemVer.Patch') }}
+        run: yarn version --patch
+      - name: Push commit and tag ↗️
+        run: git push --follow-tags -f
+      - name: Set LATEST_TAG environment variable ⚙️
+        run: |
+          latestTag="$(git describe --abbrev=0 --tags)"
+
+          echo 'LATEST_TAG='$latestTag >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish package on NPM 📦
+        run: yarn run prepare && cd dist && yarn run publish --no-git-tag-version --new-version $LATEST_TAG && cd ..
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  release_note:
+    name: Release note
+    needs: [if_merged]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set LATEST_TAG environment variable ⚙️
+        run: |
+          latestTag="$(git describe --abbrev=0 --tags)"
+          currentBranch="$(git branch --show-current)"
+
+          echo 'LATEST_TAG='$latestTag >> $GITHUB_ENV
+          echo 'CURRENT_BRANCH='$currentBranch >> $GITHUB_ENV
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create a release 📝
+        run: gh api --method POST /repos/icure/icure-typescript-sdk/releases -f tag_name="$LATEST_TAG" -f target_commitish="$CURRENT_BRANCH" -f name="$LATEST_TAG" -F draft=false -F generate_release_notes=true -F prerelease=false
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
This workflow's goal is to automatically manage the release on NPM and Github.

It'll be triggered when there's a closed pull request either on `main` or a branch starting by `support/**`. If the PR have been merge and have either `SemVar.Major`, `SemVer.Minor`, `SemVer.Patch` label attach to it, then the process will proceed.

The release management script will use the release config (located at `.github/release.yml`) to generate a bullet-list of all the changes and prefix it with all the PR first comment (if there's one) as migration/technical notes.

## TODO:
- Set a NPM_TOKEN in the repository secrets (NPM token)
- Set a RELEASE_TOKEN in the repository secrets (Github Personnal Access token)