### PR TITLE
Fix full keys in hcPartyKeys migrated to aesExchangeKeys (EHR-117)

### DIFF
--- a/icc-x-api/icc-crypto-x-api.ts
+++ b/icc-x-api/icc-crypto-x-api.ts
@@ -361,7 +361,8 @@ export class IccCryptoXApi {
         return
       }
 
-      let encryptedHcPartyKey = encryptedHcPartyKeys[fingerprint]
+      // Due to past bugs the encryptedHcPartyKeys may contain the full key instead of just the fingerprint.
+      let encryptedHcPartyKey = encryptedHcPartyKeys[fingerprint] ?? encryptedHcPartyKeys[pk]
       if (!encryptedHcPartyKey) {
         const delegate = await this.getDataOwner(delegateHcPartyId, false) //it is faster to just try to decrypt if not in cache
         if (!delegate?.dataOwner || delegate.dataOwner.publicKey?.endsWith(fingerprint)) {
@@ -2091,7 +2092,7 @@ export class IccCryptoXApi {
           [ownerLegacyPublicKey]: Object.entries(owner.hcPartyKeys ?? {}).reduce(
             (map, [hcpId, keys]) => ({
               ...map,
-              [hcpId]: { [ownerLegacyPublicKey]: keys[0], [counterParts.find((x) => x.id === hcpId)?.publicKey ?? '']: keys[1] },
+              [hcpId]: { [ownerLegacyPublicKey.slice(-32)]: keys[0], [counterParts.find((x) => x.id === hcpId)?.publicKey ?? '']: keys[1] },
               ...{},
             }),
             {}


### PR DESCRIPTION
The logic for the migration of the legacy `hcPartyKeys` to `aesExchangeKeys` had a bug where instead of using only the fingerprints of the public keys as the encrypted data map entry keys it was using the full public key.
Apart from being a waste of storage this was also causing decryption errors in some scenarios.

Changes:
- Fix the bug so new migrated keys will only use the fingerprint
- Support full keys during decryption
- Add a fixer to automatically replace the full public key with the fingerprint on each `aesExchangeKeys` update