### PR TITLE
Fix full keys in hcPartyKeys migrated to aesExchangeKeys (EHR-117) v5

### DIFF
--- a/icc-x-api/icc-crypto-x-api.ts
+++ b/icc-x-api/icc-crypto-x-api.ts
@@ -363,7 +363,8 @@ export class IccCryptoXApi {
         return
       }
 
-      let encryptedHcPartyKey = encryptedHcPartyKeys[fingerprint]
+      // Due to past bugs the encryptedHcPartyKeys may contain the full key instead of just the fingerprint.
+      let encryptedHcPartyKey = encryptedHcPartyKeys[fingerprint] ?? encryptedHcPartyKeys[pk]
       if (!encryptedHcPartyKey) {
         const delegate = await this.getDataOwner(delegateHcPartyId, false) //it is faster to just try to decrypt if not in cache
         if (!delegate?.dataOwner || delegate.dataOwner.publicKey?.endsWith(fingerprint)) {
@@ -2097,7 +2098,7 @@ export class IccCryptoXApi {
           [ownerLegacyPublicKey]: Object.entries(owner.hcPartyKeys ?? {}).reduce(
             (map, [hcpId, keys]) => ({
               ...map,
-              [hcpId]: { [ownerLegacyPublicKey]: keys[0], [counterParts.find((x) => x.id === hcpId)?.publicKey ?? '']: keys[1] },
+              [hcpId]: { [ownerLegacyPublicKey.slice(-32)]: keys[0], [counterParts.find((x) => x.id === hcpId)?.publicKey ?? '']: keys[1] },
               ...{},
             }),
             {}

--- a/icc-x-api/icc-crypto-x-api.ts
+++ b/icc-x-api/icc-crypto-x-api.ts
@@ -2128,10 +2128,10 @@ export class IccCryptoXApi {
         if (delegate.publicKey && ownerLegacyPublicKey && isOwnerLegacyPublicKeyAvailable) {
           owner.hcPartyKeys![delegateId] = [encryptedAesKeys[ownerLegacyPublicKey.slice(-32)], encryptedAesKeys[delegate.publicKey.slice(-32)]]
         }
-        owner.aesExchangeKeys = {
+        owner.aesExchangeKeys = this.fixAesExchangeKeyEntriesToFingerprints({
           ...(ownerCombinedAesExchangeKeys ?? {}),
           [selectedPublicKey]: { ...(owner.aesExchangeKeys?.[selectedPublicKey] ?? {}), [delegateId]: encryptedAesKeys },
-        }
+        })
 
         return new Promise<['hcp', HealthcareParty] | ['patient', Patient] | ['device', Device]>((resolve, reject) => {
           ownerType === 'hcp'
@@ -2275,5 +2275,26 @@ export class IccCryptoXApi {
    */
   storeKeyPair(id: string, keyPair: { publicKey: any; privateKey: any }) {
     this._storage.setItem(this.rsaLocalStoreIdPrefix + id, JSON.stringify(keyPair))
+  }
+
+  fixAesExchangeKeyEntriesToFingerprints(
+    aesExchangeKeys: { [delegatorPubKey: string]: { [delegateId: string]: { [pubKeyFp: string]: string } } }
+  ): { [delegatorPubKey: string]: { [delegateId: string]: { [pubKeyFp: string]: string } } } {
+    return Object.fromEntries(
+      Object.entries(aesExchangeKeys).map(([delegatorPubKey, allDelegates]) => [
+        delegatorPubKey,
+        Object.fromEntries(
+          Object.entries(allDelegates).map(([delegateId, keyEntries]) => [
+            delegateId,
+            Object.fromEntries(
+              Object.entries(keyEntries).map(([publicKey, encryptedValue]) => [
+                publicKey.slice(-32),
+                encryptedValue
+              ])
+            )
+          ])
+        )
+      ])
+    )
   }
 }


### PR DESCRIPTION
The logic for the migration of the legacy `hcPartyKeys` to `aesExchangeKeys` had a bug where instead of using only the fingerprints of the public keys as the encrypted data map entry keys it was using the full public key.
Apart from being a waste of storage this was also causing decryption errors in some scenarios.

Changes:
- Fix the bug so new migrated keys will only use the fingerprint
- Support full keys during decryption
- Add a fixer to automatically replace the full public key with the fingerprint on each `aesExchangeKeys` update