### PR TITLE
Add filter and fix entity encryption keys method to xapi encrypt/decrypt

### DIFF
--- a/icc-x-api/crypto/AES.ts
+++ b/icc-x-api/crypto/AES.ts
@@ -1,4 +1,4 @@
-import { appendBuffer, ua2hex } from '../utils'
+import { appendBuffer, hex2ua, ua2hex } from '../utils'
 
 export class AESUtils {
   /********* AES Config **********/
@@ -168,7 +168,15 @@ export class AESUtils {
     return new Promise((resolve: (value: CryptoKey) => any, reject: (reason: any) => any) => {
       const extractable = true
       const keyUsages: KeyUsage[] = ['decrypt', 'encrypt']
-      return this.crypto.subtle.importKey(format as any, aesKey as any, this.aesImportParams, extractable, keyUsages).then(resolve, reject)
+      return this.crypto.subtle
+        .importKey(format as any, aesKey as any, this.aesImportParams, extractable, keyUsages)
+        .catch((err) => {
+          if (format == 'raw' && (aesKey instanceof ArrayBuffer || ArrayBuffer.isView(aesKey))) {
+            console.warn(`Import of key ${ua2hex(aesKey)} failed`)
+          }
+          throw err
+        })
+        .then(resolve, reject)
     })
   }
 }

--- a/icc-x-api/crypto/AES.ts
+++ b/icc-x-api/crypto/AES.ts
@@ -9,6 +9,9 @@ export class AESUtils {
     name: 'AES-CBC',
     length: 256,
   }
+
+  private aesImportParams: AlgorithmIdentifier = { name: this.aesAlgorithmEncryptName }
+
   private crypto: Crypto
   private _debug: boolean = false
 
@@ -165,7 +168,7 @@ export class AESUtils {
     return new Promise((resolve: (value: CryptoKey) => any, reject: (reason: any) => any) => {
       const extractable = true
       const keyUsages: KeyUsage[] = ['decrypt', 'encrypt']
-      return this.crypto.subtle.importKey(format as any, aesKey as any, this.aesKeyGenParams, extractable, keyUsages).then(resolve, reject)
+      return this.crypto.subtle.importKey(format as any, aesKey as any, this.aesImportParams, extractable, keyUsages).then(resolve, reject)
     })
   }
 }

--- a/icc-x-api/icc-accesslog-x-api.ts
+++ b/icc-x-api/icc-accesslog-x-api.ts
@@ -105,9 +105,9 @@ export class IccAccesslogXApi extends IccAccesslogApi {
       .extractDelegationsSFKs(patient, hcpartyId)
       .then((secretForeignKeys) =>
         secretForeignKeys && secretForeignKeys.extractedKeys && secretForeignKeys.extractedKeys.length > 0
-          ? (usingPost ?
-            this.findByHCPartyPatientSecretFKeysArray(secretForeignKeys.hcpartyId!, _.uniq(secretForeignKeys.extractedKeys)) :
-            this.findByHCPartyPatientSecretFKeys(secretForeignKeys.hcpartyId!, _.uniq(secretForeignKeys.extractedKeys).join(',')))
+          ? usingPost
+            ? this.findByHCPartyPatientSecretFKeysArray(secretForeignKeys.hcpartyId!, _.uniq(secretForeignKeys.extractedKeys))
+            : this.findByHCPartyPatientSecretFKeys(secretForeignKeys.hcpartyId!, _.uniq(secretForeignKeys.extractedKeys).join(','))
           : Promise.resolve([])
       )
   }
@@ -133,11 +133,12 @@ export class IccAccesslogXApi extends IccAccesslogApi {
                 _.size(accessLog.encryptionKeys) ? accessLog.encryptionKeys! : accessLog.delegations!
               )
               .then(({ extractedKeys: sfks }) => {
+                sfks = this.crypto.filterAndFixValidEntityEncryptionKeyStrings(sfks)
                 if (!sfks || !sfks.length) {
                   //console.log("Cannot decrypt contact", ctc.id)
                   return Promise.resolve(accessLog)
                 }
-                return this.crypto.AES.importKey('raw', hex2ua(sfks[0].replace(/-/g, ''))).then((key) =>
+                return this.crypto.AES.importKey('raw', hex2ua(sfks[0])).then((key) =>
                   decrypt(accessLog, (ec) =>
                     this.crypto.AES.decrypt(key, ec).then((dec) => {
                       const jsonContent = dec && ua2utf8(dec)
@@ -190,11 +191,12 @@ export class IccAccesslogXApi extends IccAccesslogApi {
             this.crypto.extractKeysFromDelegationsForHcpHierarchy(this.dataOwnerApi.getDataOwnerOf(user)!, accessLog.id!, accessLog.encryptionKeys!)
           )
           .then(async (eks: { extractedKeys: Array<string>; hcpartyId: string }) => {
-            const rawKey = eks.extractedKeys[0].replace(/-/g, '')
-            const key = await this.crypto.AES.importKey('raw', hex2ua(rawKey))
+            const keys = this.crypto.filterAndFixValidEntityEncryptionKeyStrings(eks.extractedKeys)
+            if (!keys.length) throw new Error('No valid keys found for calendar item encryption')
+            const key = await this.crypto.AES.importKey('raw', hex2ua(keys[0]))
             return crypt(
               accessLog,
-              (obj: { [key: string]: string }) => this.crypto.AES.encrypt(key, utf8_2ua(JSON.stringify(obj)), rawKey),
+              (obj: { [key: string]: string }) => this.crypto.AES.encrypt(key, utf8_2ua(JSON.stringify(obj)), keys[0]),
               this.cryptedKeys
             )
           })

--- a/icc-x-api/icc-form-x-api.ts
+++ b/icc-x-api/icc-form-x-api.ts
@@ -133,9 +133,15 @@ export class IccFormXApi extends IccFormApi {
     return this.crypto
       .extractDelegationsSFKs(patient, hcpartyId)
       .then((secretForeignKeys) =>
-        usingPost ?
-          this.findFormsByHCPartyPatientForeignKeysUsingPost(secretForeignKeys.hcpartyId!, undefined, undefined, undefined, _.uniq(secretForeignKeys.extractedKeys)) :
-          this.findFormsByHCPartyPatientForeignKeys(secretForeignKeys.hcpartyId!, _.uniq(secretForeignKeys.extractedKeys).join(','))
+        usingPost
+          ? this.findFormsByHCPartyPatientForeignKeysUsingPost(
+              secretForeignKeys.hcpartyId!,
+              undefined,
+              undefined,
+              undefined,
+              _.uniq(secretForeignKeys.extractedKeys)
+            )
+          : this.findFormsByHCPartyPatientForeignKeys(secretForeignKeys.hcpartyId!, _.uniq(secretForeignKeys.extractedKeys).join(','))
       )
       .then((forms) => this.decrypt(hcpartyId, forms))
       .then(function (decryptedForms) {
@@ -150,7 +156,8 @@ export class IccFormXApi extends IccFormApi {
           .extractKeysFromDelegationsForHcpHierarchy(hcpartyId, form.id!, _.size(form.encryptionKeys) ? form.encryptionKeys! : form.delegations!)
           .then(({ extractedKeys: sfks }) => {
             if (form.encryptedSelf) {
-              return this.crypto.AES.importKey('raw', hex2ua(sfks[0].replace(/-/g, '')))
+              sfks = this.crypto.filterAndFixValidEntityEncryptionKeyStrings(sfks)
+              return this.crypto.AES.importKey('raw', hex2ua(sfks[0]))
                 .then(
                   (key) =>
                     new Promise((resolve: (value: any) => any) => {

--- a/icc-x-api/icc-maintenance-task-x-api.ts
+++ b/icc-x-api/icc-maintenance-task-x-api.ts
@@ -177,9 +177,11 @@ export class IccMaintenanceTaskXApi extends IccMaintenanceTaskApi {
           : this.initEncryptionKeys(user, m)
         )
           .then((m: models.MaintenanceTask) => this.crypto.extractKeysFromDelegationsForHcpHierarchy(dataOwnerId!, m.id!, m.encryptionKeys!))
-          .then((sfks: { extractedKeys: Array<string>; hcpartyId: string }) =>
-            this.crypto.AES.importKey('raw', hex2ua(sfks.extractedKeys[0].replace(/-/g, '')))
-          )
+          .then((sfks: { extractedKeys: Array<string>; hcpartyId: string }) => {
+            const keys = this.crypto.filterAndFixValidEntityEncryptionKeyStrings(sfks.extractedKeys)
+            if (!keys.length) throw new Error('No valid keys found for calendar item encryption')
+            return this.crypto.AES.importKey('raw', hex2ua(keys[0]))
+          })
           .then((key: CryptoKey) =>
             crypt(
               m,
@@ -207,12 +209,13 @@ export class IccMaintenanceTaskXApi extends IccMaintenanceTaskApi {
     return Promise.all(
       maintenanceTasks.map((mT) =>
         this.crypto.extractKeysFromDelegationsForHcpHierarchy(dataOwnerId, mT.id!, mT.encryptionKeys ?? {}).then(({ extractedKeys: sfks }) => {
+          sfks = this.crypto.filterAndFixValidEntityEncryptionKeyStrings(sfks)
           if (!sfks || !sfks.length) {
             console.log('Cannot decrypt maintenanceTask', mT.id)
             return Promise.resolve(mT)
           }
           if (mT.encryptedSelf) {
-            return this.crypto.AES.importKey('raw', hex2ua(sfks[0].replace(/-/g, ''))).then(
+            return this.crypto.AES.importKey('raw', hex2ua(sfks[0])).then(
               (key) =>
                 new Promise((resolve: (value: any) => any) =>
                   this.crypto.AES.decrypt(key, string2ua(a2b(mT.encryptedSelf!))).then(

--- a/test/icc-x-api/crypto/key-fixing-test.ts
+++ b/test/icc-x-api/crypto/key-fixing-test.ts
@@ -1,0 +1,39 @@
+import { before } from 'mocha'
+import { getEnvironmentInitializer, getEnvVariables, TestVars } from '../../utils/test_utils'
+import { webcrypto } from 'crypto'
+import { hex2ua, IccCryptoXApi, ua2hex, ua2utf8, utf8_2ua } from '../../../icc-x-api'
+import { AESUtils } from '../../../icc-x-api/crypto/AES'
+import { expect } from 'chai'
+
+describe('Test key validation', () => {
+  before(async function () {
+    this.timeout(600000)
+  })
+
+  it('key validation should only keep valid keys', async () => {
+    const cryptoApi = new IccCryptoXApi(null as any, null as any, null as any, null as any, null as any, webcrypto as any, null as any, null as any)
+    const uuidKey = cryptoApi.randomUuid()
+    const validKeysCorrect = [
+      'a'.repeat(32),
+      'a'.repeat(64),
+      ua2hex(webcrypto.getRandomValues(new Uint8Array(16))),
+      ua2hex(webcrypto.getRandomValues(new Uint8Array(32))),
+    ]
+
+    const invalidKeys = [
+      'a'.repeat(30),
+      'a'.repeat(31),
+      'a'.repeat(33),
+      'a'.repeat(34),
+      'a'.repeat(63),
+      'a'.repeat(65),
+      ua2hex(webcrypto.getRandomValues(new Uint8Array(31))),
+      ua2hex(webcrypto.getRandomValues(new Uint8Array(33))),
+      ua2hex(webcrypto.getRandomValues(new Uint8Array(31))) + 'x',
+    ]
+    expect(cryptoApi.filterAndFixValidEntityEncryptionKeyStrings([uuidKey, ...validKeysCorrect, ...invalidKeys])).to.have.members([
+      uuidKey.replace(/-/g, ''),
+      ...validKeysCorrect,
+    ])
+  })
+})


### PR DESCRIPTION
Ignore invalid keys before attempting to import them and use them for decryption (`filterAndFixValidEntityEncryptionKeyStrings`). Prevents errors from undetected usage of the wrong aes exchange keys on decryption.