### PR TITLE
Extended crypted field syntax

### DIFF
--- a/icc-x-api/crypto/EntitiesEncryption.ts
+++ b/icc-x-api/crypto/EntitiesEncryption.ts
@@ -1,7 +1,7 @@
 import { Delegation, EncryptedEntity, EncryptedEntityStub } from '../../icc-api/model/models'
 import { IccDataOwnerXApi } from '../icc-data-owner-x-api'
 import { ExchangeKeysManager } from './ExchangeKeysManager'
-import { b2a, crypt, decrypt, hex2ua, string2ua, truncateTrailingNulls, ua2hex, ua2string, ua2utf8, utf8_2ua } from '../utils'
+import { b2a, crypt, decrypt, hex2ua, parseEncryptedFields, string2ua, truncateTrailingNulls, ua2hex, ua2string, ua2utf8, utf8_2ua } from '../utils'
 import * as _ from 'lodash'
 import { CryptoPrimitives } from './CryptoPrimitives'
 import { arrayEquals } from '../utils/collection-utils'
@@ -436,7 +436,6 @@ export class EntitiesEncryption {
     ownerId: string | undefined,
     constructor: (json: any) => T
   ): Promise<{ entity: T; decrypted: boolean }> {
-    if (!entity.encryptedSelf) return { entity, decrypted: true }
     const encryptionKeys = await this.importAllValidKeys(await this.encryptionKeysOf(entity, ownerId))
     if (!encryptionKeys.length) return { entity, decrypted: false }
     return {
@@ -490,7 +489,7 @@ export class EntitiesEncryption {
     if (!!encryptionKey) {
       return constructor(
         await crypt(
-          entityWithInitialisedEncryptionKeys,
+          entityWithInitialisedEncryptionKeys ?? entity,
           (obj) => {
             const json = encodeBinaryData
               ? JSON.stringify(obj, (k, v) => {
@@ -501,24 +500,27 @@ export class EntitiesEncryption {
               : JSON.stringify(obj)
             return this.primitives.AES.encrypt(encryptionKey.key, utf8_2ua(json), encryptionKey.raw)
           },
-          cryptedKeys
+          parseEncryptedFields(cryptedKeys, 'Unknown.'), // TODO tmp
+          'entity'
         )
       )
     } else if (requireEncryption) {
       throw new Error(`No key found for encryption of entity ${entity}`)
     } else {
-      const cryptedCopyWithRandomKey = await crypt(
-        _.cloneDeep(entity),
-        async (obj: { [key: string]: string }) => Promise.resolve(new ArrayBuffer(1)),
-        cryptedKeys
+      let encryptedNonEmptyData = false
+      await crypt(
+        entity,
+        async (obj: { [key: string]: string }) => {
+          if (Object.keys(obj).length > 0) {
+            encryptedNonEmptyData = true
+          }
+          return Promise.resolve(new ArrayBuffer(1))
+        },
+        parseEncryptedFields(cryptedKeys, 'Unknown.'), // TODO tmp
+        'entity'
       )
-      if (
-        !_.isEqual(
-          _.omitBy({ ...cryptedCopyWithRandomKey, encryptedSelf: undefined }, _.isNil),
-          _.omitBy({ ...entity, encryptedSelf: undefined }, _.isNil)
-        )
-      ) {
-        throw new Error(`Impossible to modify encrypted value of an entity if no encryption key is known.\n${entity}`)
+      if (encryptedNonEmptyData) {
+        throw new Error(`Impossible to modify encrypted content of an entity if no encryption key is known.\n${entity}`)
       }
       return entity
     }
@@ -531,7 +533,7 @@ export class EntitiesEncryption {
    * which were previously not encrypted.
    */
   async ensureEncryptionKeysInitialised<T extends EncryptedEntity>(entity: T): Promise<T | undefined> {
-    if (Object.keys(entity.encryptionKeys ?? {}).length > 0) return entity
+    if (Object.keys(entity.encryptionKeys ?? {}).length > 0) return undefined
     if (!entity.rev) {
       throw new Error(
         'New encrypted entity is lacking encryption metadata. ' +

--- a/icc-x-api/icc-accesslog-x-api.ts
+++ b/icc-x-api/icc-accesslog-x-api.ts
@@ -7,14 +7,14 @@ import { IccDataOwnerXApi } from './icc-data-owner-x-api'
 import { AuthenticationProvider, NoAuthenticationProvider } from './auth/AuthenticationProvider'
 import { ShareMetadataBehaviour } from './crypto/ShareMetadataBehaviour'
 import { EncryptedEntityXApi } from './basexapi/EncryptedEntityXApi'
-import { EncryptedFieldsKeys, parseEncryptedFields } from './utils'
+import { EncryptedFieldsManifest, parseEncryptedFields } from './utils'
 
 export interface AccessLogWithPatientId extends AccessLog {
   patientId: string
 }
 
 export class IccAccesslogXApi extends IccAccesslogApi implements EncryptedEntityXApi<models.AccessLog> {
-  private readonly encryptedFields: EncryptedFieldsKeys
+  private readonly encryptedFields: EncryptedFieldsManifest
   crypto: IccCryptoXApi
   dataOwnerApi: IccDataOwnerXApi
 

--- a/icc-x-api/icc-calendar-item-x-api.ts
+++ b/icc-x-api/icc-calendar-item-x-api.ts
@@ -9,12 +9,13 @@ import { IccDataOwnerXApi } from './icc-data-owner-x-api'
 import { AuthenticationProvider, NoAuthenticationProvider } from './auth/AuthenticationProvider'
 import { ShareMetadataBehaviour } from './crypto/ShareMetadataBehaviour'
 import { EncryptedEntityXApi } from './basexapi/EncryptedEntityXApi'
+import { EncryptedFieldsKeys, parseEncryptedFields } from './utils'
 
 export class IccCalendarItemXApi extends IccCalendarItemApi implements EncryptedEntityXApi<models.CalendarItem> {
   i18n: any = i18n
   crypto: IccCryptoXApi
   dataOwnerApi: IccDataOwnerXApi
-  encryptedKeys = ['details', 'title', 'patientId']
+  private readonly encryptedFields: EncryptedFieldsKeys
 
   constructor(
     host: string,
@@ -32,7 +33,7 @@ export class IccCalendarItemXApi extends IccCalendarItemApi implements Encrypted
     super(host, headers, authenticationProvider, fetchImpl)
     this.crypto = crypto
     this.dataOwnerApi = dataOwnerApi
-    this.encryptedKeys = encryptedKeys
+    this.encryptedFields = parseEncryptedFields(encryptedKeys, 'CalendarItem.')
   }
 
   newInstance(user: User, ci: CalendarItem, options: { additionalDelegates?: { [dataOwnerId: string]: 'WRITE' } } = {}) {
@@ -223,7 +224,7 @@ export class IccCalendarItemXApi extends IccCalendarItemApi implements Encrypted
   private encryptAs(dataOwnerId: string, calendarItems: Array<models.CalendarItem>): Promise<Array<models.CalendarItem>> {
     return Promise.all(
       calendarItems.map((x) =>
-        this.crypto.entities.tryEncryptEntity(x, dataOwnerId, this.encryptedKeys, false, true, (json) => new CalendarItem(json))
+        this.crypto.entities.tryEncryptEntity(x, dataOwnerId, this.encryptedFields, false, true, (json) => new CalendarItem(json))
       )
     )
   }

--- a/icc-x-api/icc-calendar-item-x-api.ts
+++ b/icc-x-api/icc-calendar-item-x-api.ts
@@ -9,13 +9,13 @@ import { IccDataOwnerXApi } from './icc-data-owner-x-api'
 import { AuthenticationProvider, NoAuthenticationProvider } from './auth/AuthenticationProvider'
 import { ShareMetadataBehaviour } from './crypto/ShareMetadataBehaviour'
 import { EncryptedEntityXApi } from './basexapi/EncryptedEntityXApi'
-import { EncryptedFieldsKeys, parseEncryptedFields } from './utils'
+import { EncryptedFieldsManifest, parseEncryptedFields } from './utils'
 
 export class IccCalendarItemXApi extends IccCalendarItemApi implements EncryptedEntityXApi<models.CalendarItem> {
   i18n: any = i18n
   crypto: IccCryptoXApi
   dataOwnerApi: IccDataOwnerXApi
-  private readonly encryptedFields: EncryptedFieldsKeys
+  private readonly encryptedFields: EncryptedFieldsManifest
 
   constructor(
     host: string,

--- a/icc-x-api/icc-contact-x-api.ts
+++ b/icc-x-api/icc-contact-x-api.ts
@@ -54,7 +54,7 @@ export class IccContactXApi extends IccContactApi implements EncryptedEntityXApi
     if (contactEncryptedKeys.some((key) => key.startsWith('services'))) {
       throw new Error("You can't customise encryption of the `services` field of Contact. Use the serviceEncryptedKeys parameter instead.")
     }
-    if (serviceEncryptedKeys.some((key) => !key.startsWith('content'))) {
+    if (serviceEncryptedKeys.some((key) => key.startsWith('content'))) {
       throw new Error("You can't customise encryption of the `content` of a Service. The content values for services is automatically encrypted.")
     }
     this.crypto = crypto

--- a/icc-x-api/icc-contact-x-api.ts
+++ b/icc-x-api/icc-contact-x-api.ts
@@ -8,10 +8,10 @@ import * as _ from 'lodash'
 import * as models from '../icc-api/model/models'
 import { Contact, FilterChainService, ListOfIds, Service } from '../icc-api/model/models'
 import { PaginatedListContact } from '../icc-api/model/PaginatedListContact'
-import { a2b, b2a, string2ua, ua2string, utf8_2ua } from './utils/binary-utils'
+import { utf8_2ua } from './utils/binary-utils'
 import { ServiceByIdsFilter } from './filters/ServiceByIdsFilter'
 import { IccDataOwnerXApi } from './icc-data-owner-x-api'
-import { before } from './utils'
+import { before, crypt, decrypt, EncryptedFieldsKeys, parseEncryptedFields } from './utils'
 import { AuthenticationProvider, NoAuthenticationProvider } from './auth/AuthenticationProvider'
 import { ShareMetadataBehaviour } from './crypto/ShareMetadataBehaviour'
 import { EncryptedEntityXApi } from './basexapi/EncryptedEntityXApi'
@@ -20,7 +20,22 @@ export class IccContactXApi extends IccContactApi implements EncryptedEntityXApi
   i18n: any = i18n
   crypto: IccCryptoXApi
   dataOwnerApi: IccDataOwnerXApi
+  private readonly contactEncryptedFields: EncryptedFieldsKeys
+  private readonly serviceEncryptedFields: EncryptedFieldsKeys
+  private readonly serviceCustomEncryptedFieldsAndContent: EncryptedFieldsKeys
 
+  /**
+   *
+   * @param host
+   * @param headers
+   * @param crypto
+   * @param dataOwnerApi
+   * @param authenticationProvider
+   * @param fetchImpl
+   * @param contactEncryptedKeys custom encrypted fields for Contact. Note that to customise the encryption of contained services (`services` field),
+   * you need to use the serviceEncryptedKeys parameter.
+   * @param serviceEncryptedKeys custom encrypted fields for Service. Note that you can't customise encryption of the `content` field
+   */
   constructor(
     host: string,
     headers: { [key: string]: string },
@@ -31,11 +46,25 @@ export class IccContactXApi extends IccContactApi implements EncryptedEntityXApi
       ? window.fetch
       : typeof self !== 'undefined'
       ? self.fetch
-      : fetch
+      : fetch,
+    contactEncryptedKeys: string[] = ['descr'],
+    serviceEncryptedKeys: string[] = []
   ) {
     super(host, headers, authenticationProvider, fetchImpl)
+    if (contactEncryptedKeys.some((key) => key.startsWith('services'))) {
+      throw new Error("You can't customise encryption of the `services` field of Contact. Use the serviceEncryptedKeys parameter instead.")
+    }
+    if (serviceEncryptedKeys.some((key) => !key.startsWith('content'))) {
+      throw new Error("You can't customise encryption of the `content` of a Service. The content values for services is automatically encrypted.")
+    }
     this.crypto = crypto
     this.dataOwnerApi = dataOwnerApi
+    this.contactEncryptedFields = parseEncryptedFields(contactEncryptedKeys, 'Contact.')
+    this.serviceEncryptedFields = parseEncryptedFields(serviceEncryptedKeys, 'Service.')
+    this.serviceCustomEncryptedFieldsAndContent = {
+      ...this.serviceEncryptedFields,
+      topLevelFields: [...this.serviceEncryptedFields.topLevelFields, { fieldName: 'content', fieldPath: 'Service.content' }],
+    }
   }
 
   /**
@@ -343,11 +372,8 @@ export class IccContactXApi extends IccContactApi implements EncryptedEntityXApi
   encryptServices(key: CryptoKey, rawKey: string, services: Service[]): PromiseLike<Service[]> {
     return Promise.all(
       services.map(async (svc) => {
-        if (!svc.content) {
-          return svc
-        }
-
         if (
+          svc.content &&
           Object.values(svc.content).every(
             (c) =>
               c.compoundValue &&
@@ -362,23 +388,36 @@ export class IccContactXApi extends IccContactApi implements EncryptedEntityXApi
               !c.binaryValue
           )
         ) {
-          svc.content = _.fromPairs(
+          const recursivelyEncryptedContent = Object.fromEntries(
             await Promise.all(
-              _.toPairs(svc.content).map(async (p) => {
+              Object.entries(svc.content).map(async (p) => {
                 if (p[1].compoundValue?.length) {
-                  p[1].compoundValue = await this.encryptServices(key, rawKey, p[1].compoundValue!)
-                }
-                return p
+                  return [p[0], { ...p[1], compoundValue: await this.encryptServices(key, rawKey, p[1].compoundValue!) }]
+                } else return p
               })
             )
           )
-        } else {
-          svc.encryptedSelf = b2a(
-            ua2string(await this.crypto.primitives.AES.encrypt(key, utf8_2ua(JSON.stringify({ content: svc.content })), rawKey))
+          return crypt(
+            {
+              ...svc,
+              content: recursivelyEncryptedContent,
+            },
+            (obj) => {
+              return this.crypto.primitives.AES.encrypt(key, utf8_2ua(JSON.stringify(obj)), rawKey)
+            },
+            this.serviceEncryptedFields,
+            'service'
           )
-          delete svc.content
+        } else {
+          return crypt(
+            svc,
+            (obj) => {
+              return this.crypto.primitives.AES.encrypt(key, utf8_2ua(JSON.stringify(obj)), rawKey)
+            },
+            this.serviceCustomEncryptedFieldsAndContent,
+            'service'
+          )
         }
-        return svc
       })
     )
   }
@@ -398,13 +437,19 @@ export class IccContactXApi extends IccContactApi implements EncryptedEntityXApi
 
         const encryptionKey = await this.crypto.entities.importFirstValidKey(await this.crypto.entities.encryptionKeysOf(ctc, hcpartyId), ctc.id!)
 
-        initialisedCtc.services = await this.encryptServices(encryptionKey.key, encryptionKey.raw, ctc.services || [])
-        initialisedCtc.encryptedSelf = b2a(
-          ua2string(await this.crypto.primitives.AES.encrypt(encryptionKey.key, utf8_2ua(JSON.stringify({ descr: ctc.descr })), encryptionKey.raw))
+        return new Contact(
+          await crypt(
+            {
+              ...initialisedCtc,
+              services: initialisedCtc.services ? await this.encryptServices(encryptionKey.key, encryptionKey.raw, initialisedCtc.services) : [],
+            },
+            (obj) => {
+              return this.crypto.primitives.AES.encrypt(encryptionKey.key, utf8_2ua(JSON.stringify(obj)), encryptionKey.raw)
+            },
+            this.contactEncryptedFields,
+            'contact'
+          )
         )
-        delete initialisedCtc.descr
-
-        return initialisedCtc
       })
     )
   }
@@ -417,20 +462,11 @@ export class IccContactXApi extends IccContactApi implements EncryptedEntityXApi
           console.log('Cannot decrypt contact', ctc.id)
           return ctc
         }
-        ctc.services = await this.decryptServices(hcpartyId, ctc.services || [], keys)
-        if (ctc.encryptedSelf) {
-          try {
-            const json = await this.crypto.entities.tryDecryptJson(keys, string2ua(a2b(ctc.encryptedSelf!)), false)
-            if (json) {
-              _.assign(ctc, json)
-            } else {
-              console.log('Cannot decrypt ctc: no valid key could produce valid json', ctc.id)
-            }
-          } catch (e) {
-            console.log('Failed to decrypt ctc', ctc.id, e)
-          }
-        }
-        return ctc
+        return new Contact(
+          await decrypt(ctc, async (encrypted) => {
+            return (await this.crypto.entities.tryDecryptJson(keys, encrypted, false)) ?? {}
+          })
+        )
       })
     )
   }
@@ -442,41 +478,11 @@ export class IccContactXApi extends IccContactApi implements EncryptedEntityXApi
           keys = await this.crypto.entities.importAllValidKeys(await this.crypto.entities.encryptionKeysOf(svc, hcpartyId))
         }
 
-        if (svc.encryptedContent) {
-          try {
-            const json = await this.crypto.entities.tryDecryptJson(keys, string2ua(a2b(svc.encryptedContent!)), true)
-            if (json) {
-              Object.assign(svc, { content: json })
-            } else {
-              console.log('Cannot decrypt service: no valid key could produce valid json', svc.id)
-            }
-          } catch (e) {
-            console.log('Cannot decrypt service', svc.id, e)
-          }
-        } else if (svc.encryptedSelf) {
-          try {
-            const json = await this.crypto.entities.tryDecryptJson(keys, string2ua(a2b(svc.encryptedSelf!)), true)
-            if (json) {
-              Object.assign(svc, json)
-            } else {
-              console.log('Cannot decrypt service: no valid key could produce valid json', svc.id)
-            }
-          } catch (e) {
-            console.log('Cannot decrypt service', svc.id, e)
-          }
-        } else {
-          svc.content = _.fromPairs(
-            await Promise.all(
-              _.toPairs(svc.content).map(async (p) => {
-                if (p[1].compoundValue) {
-                  p[1].compoundValue = await this.decryptServices(hcpartyId, p[1].compoundValue, keys)
-                }
-                return p
-              })
-            )
-          )
-        }
-        return svc
+        return new Contact(
+          await decrypt(svc, async (encrypted) => {
+            return (await this.crypto.entities.tryDecryptJson(keys!, encrypted, false)) ?? {}
+          })
+        )
       })
     )
   }

--- a/icc-x-api/icc-helement-x-api.ts
+++ b/icc-x-api/icc-helement-x-api.ts
@@ -10,12 +10,12 @@ import { IccDataOwnerXApi } from './icc-data-owner-x-api'
 import { AuthenticationProvider, NoAuthenticationProvider } from './auth/AuthenticationProvider'
 import { ShareMetadataBehaviour } from './crypto/ShareMetadataBehaviour'
 import { EncryptedEntityXApi } from './basexapi/EncryptedEntityXApi'
-import { EncryptedFieldsKeys, parseEncryptedFields } from './utils'
+import { EncryptedFieldsManifest, parseEncryptedFields } from './utils'
 
 export class IccHelementXApi extends IccHelementApi implements EncryptedEntityXApi<models.HealthElement> {
   crypto: IccCryptoXApi
   dataOwnerApi: IccDataOwnerXApi
-  private readonly encryptedFields: EncryptedFieldsKeys
+  private readonly encryptedFields: EncryptedFieldsManifest
 
   constructor(
     host: string,

--- a/icc-x-api/icc-helement-x-api.ts
+++ b/icc-x-api/icc-helement-x-api.ts
@@ -10,12 +10,12 @@ import { IccDataOwnerXApi } from './icc-data-owner-x-api'
 import { AuthenticationProvider, NoAuthenticationProvider } from './auth/AuthenticationProvider'
 import { ShareMetadataBehaviour } from './crypto/ShareMetadataBehaviour'
 import { EncryptedEntityXApi } from './basexapi/EncryptedEntityXApi'
+import { EncryptedFieldsKeys, parseEncryptedFields } from './utils'
 
 export class IccHelementXApi extends IccHelementApi implements EncryptedEntityXApi<models.HealthElement> {
   crypto: IccCryptoXApi
   dataOwnerApi: IccDataOwnerXApi
-
-  private readonly encryptedKeys: Array<string>
+  private readonly encryptedFields: EncryptedFieldsKeys
 
   constructor(
     host: string,
@@ -33,7 +33,7 @@ export class IccHelementXApi extends IccHelementApi implements EncryptedEntityXA
     super(host, headers, authenticationProvider, fetchImpl)
     this.crypto = crypto
     this.dataOwnerApi = dataOwnerApi
-    this.encryptedKeys = encryptedKeys
+    this.encryptedFields = parseEncryptedFields(encryptedKeys, 'HealthElement.')
   }
 
   /**
@@ -290,7 +290,7 @@ export class IccHelementXApi extends IccHelementApi implements EncryptedEntityXA
   private encryptAs(owner: string, healthElements: Array<models.HealthElement>): Promise<Array<models.HealthElement>> {
     return Promise.all(
       healthElements.map((he) =>
-        this.crypto.entities.tryEncryptEntity(he, owner, this.encryptedKeys, false, true, (x) => new models.HealthElement(x))
+        this.crypto.entities.tryEncryptEntity(he, owner, this.encryptedFields, false, true, (x) => new models.HealthElement(x))
       )
     )
   }

--- a/icc-x-api/icc-maintenance-task-x-api.ts
+++ b/icc-x-api/icc-maintenance-task-x-api.ts
@@ -8,14 +8,14 @@ import { IccDataOwnerXApi } from './icc-data-owner-x-api'
 import { AuthenticationProvider, NoAuthenticationProvider } from './auth/AuthenticationProvider'
 import { ShareMetadataBehaviour } from './crypto/ShareMetadataBehaviour'
 import { EncryptedEntityXApi } from './basexapi/EncryptedEntityXApi'
-import { EncryptedFieldsKeys, parseEncryptedFields } from './utils'
+import { EncryptedFieldsManifest, parseEncryptedFields } from './utils'
 
 export class IccMaintenanceTaskXApi extends IccMaintenanceTaskApi implements EncryptedEntityXApi<models.MaintenanceTask> {
   crypto: IccCryptoXApi
   hcPartyApi: IccHcpartyXApi
   dataOwnerApi: IccDataOwnerXApi
 
-  private readonly encryptedFields: EncryptedFieldsKeys
+  private readonly encryptedFields: EncryptedFieldsManifest
 
   constructor(
     host: string,

--- a/icc-x-api/icc-maintenance-task-x-api.ts
+++ b/icc-x-api/icc-maintenance-task-x-api.ts
@@ -8,13 +8,14 @@ import { IccDataOwnerXApi } from './icc-data-owner-x-api'
 import { AuthenticationProvider, NoAuthenticationProvider } from './auth/AuthenticationProvider'
 import { ShareMetadataBehaviour } from './crypto/ShareMetadataBehaviour'
 import { EncryptedEntityXApi } from './basexapi/EncryptedEntityXApi'
+import { EncryptedFieldsKeys, parseEncryptedFields } from './utils'
 
 export class IccMaintenanceTaskXApi extends IccMaintenanceTaskApi implements EncryptedEntityXApi<models.MaintenanceTask> {
   crypto: IccCryptoXApi
   hcPartyApi: IccHcpartyXApi
   dataOwnerApi: IccDataOwnerXApi
 
-  private readonly encryptedKeys: Array<string>
+  private readonly encryptedFields: EncryptedFieldsKeys
 
   constructor(
     host: string,
@@ -22,7 +23,7 @@ export class IccMaintenanceTaskXApi extends IccMaintenanceTaskApi implements Enc
     crypto: IccCryptoXApi,
     hcPartyApi: IccHcpartyXApi,
     dataOwnerApi: IccDataOwnerXApi,
-    encryptedKeys: Array<string> = [],
+    encryptedKeys: Array<string> = ['properties'],
     authenticationProvider: AuthenticationProvider = new NoAuthenticationProvider(),
     fetchImpl: (input: RequestInfo, init?: RequestInit) => Promise<Response> = typeof window !== 'undefined'
       ? window.fetch
@@ -34,7 +35,7 @@ export class IccMaintenanceTaskXApi extends IccMaintenanceTaskApi implements Enc
     this.crypto = crypto
     this.hcPartyApi = hcPartyApi
     this.dataOwnerApi = dataOwnerApi
-    this.encryptedKeys = encryptedKeys
+    this.encryptedFields = parseEncryptedFields(encryptedKeys, 'MaintenanceTask.')
   }
 
   /**
@@ -146,7 +147,7 @@ export class IccMaintenanceTaskXApi extends IccMaintenanceTaskApi implements Enc
   private encryptAs(dataOwnerId: string, maintenanceTasks: Array<models.MaintenanceTask>): Promise<Array<models.MaintenanceTask>> {
     return Promise.all(
       maintenanceTasks.map((m) =>
-        this.crypto.entities.tryEncryptEntity(m, dataOwnerId, this.encryptedKeys, true, true, (x) => new models.MaintenanceTask(x))
+        this.crypto.entities.tryEncryptEntity(m, dataOwnerId, this.encryptedFields, true, true, (x) => new models.MaintenanceTask(x))
       )
     )
   }

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -14,7 +14,7 @@ import { CalendarItem, Classification, Document, IcureStub, Invoice, ListOfIds, 
 import { IccCalendarItemXApi } from './icc-calendar-item-x-api'
 import { b64_2ab } from '../icc-api/model/ModelHelper'
 import { findName, garnishPersonWithName, hasName } from './utils/person-util'
-import { EncryptedFieldsKeys, parseEncryptedFields, retry } from './utils'
+import { EncryptedFieldsManifest, parseEncryptedFields, retry } from './utils'
 import { IccDataOwnerXApi } from './icc-data-owner-x-api'
 import { AuthenticationProvider, NoAuthenticationProvider } from './auth/AuthenticationProvider'
 import { ShareMetadataBehaviour } from './crypto/ShareMetadataBehaviour'
@@ -33,7 +33,7 @@ export class IccPatientXApi extends IccPatientApi implements EncryptedEntityXApi
   calendarItemApi: IccCalendarItemXApi
   dataOwnerApi: IccDataOwnerXApi
 
-  private readonly encryptedFields: EncryptedFieldsKeys
+  private readonly encryptedFields: EncryptedFieldsManifest
 
   constructor(
     host: string,

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -14,7 +14,7 @@ import { CalendarItem, Classification, Document, IcureStub, Invoice, ListOfIds, 
 import { IccCalendarItemXApi } from './icc-calendar-item-x-api'
 import { b64_2ab } from '../icc-api/model/ModelHelper'
 import { findName, garnishPersonWithName, hasName } from './utils/person-util'
-import { retry } from './utils'
+import { EncryptedFieldsKeys, parseEncryptedFields, retry } from './utils'
 import { IccDataOwnerXApi } from './icc-data-owner-x-api'
 import { AuthenticationProvider, NoAuthenticationProvider } from './auth/AuthenticationProvider'
 import { ShareMetadataBehaviour } from './crypto/ShareMetadataBehaviour'
@@ -33,7 +33,7 @@ export class IccPatientXApi extends IccPatientApi implements EncryptedEntityXApi
   calendarItemApi: IccCalendarItemXApi
   dataOwnerApi: IccDataOwnerXApi
 
-  private readonly encryptedKeys: Array<string>
+  private readonly encryptedFields: EncryptedFieldsKeys
 
   constructor(
     host: string,
@@ -68,7 +68,7 @@ export class IccPatientXApi extends IccPatientApi implements EncryptedEntityXApi
     this.calendarItemApi = calendarItemaApi
     this.dataOwnerApi = dataOwnerApi
 
-    this.encryptedKeys = encryptedKeys
+    this.encryptedFields = parseEncryptedFields(encryptedKeys, 'Patient.')
   }
 
   /**
@@ -497,7 +497,7 @@ export class IccPatientXApi extends IccPatientApi implements EncryptedEntityXApi
 
   private encryptAs(dataOwnerId: string | undefined, pats: Array<models.Patient>): Promise<Array<models.Patient>> {
     return Promise.all(
-      pats.map((p) => this.crypto.entities.tryEncryptEntity(p, dataOwnerId, this.encryptedKeys, true, false, (x) => new models.Patient(x)))
+      pats.map((p) => this.crypto.entities.tryEncryptEntity(p, dataOwnerId, this.encryptedFields, true, false, (x) => new models.Patient(x)))
     )
   }
 

--- a/icc-x-api/icc-patient-x-api.ts
+++ b/icc-x-api/icc-patient-x-api.ts
@@ -910,7 +910,8 @@ export class IccPatientXApi extends IccPatientApi implements EncryptedEntityXApi
                 })
               })
             : (allTags.includes('anonymousMedicalInformation')
-                ? Promise.resolve(patient)
+                ? // TODO check also in v8 how patient is shared with anonymousMedicalInformation tag
+                  Promise.resolve(patient)
                 : this.modifyPatientWithUser(
                     user,
                     _.assign(patient, {

--- a/icc-x-api/index.ts
+++ b/icc-x-api/index.ts
@@ -251,6 +251,8 @@ export interface EncryptedFieldsConfig {
   /**
    * Fields to encrypt for entities of type {@link Service}. Note that encryption of the `content` field and recursively contained `Services` through
    * `content.compoundValue` is automatically managed by the sdk, and you are not allowed to modify it.
+   * Note: specifying non-empty values for this field will break bi-directional data compatibility between v7 and previous: Contacts created with
+   * v7 will not be read properly by previous versions.
    * @default [] // encryption of `content` is managed in a special way
    */
   readonly service?: string[]

--- a/icc-x-api/index.ts
+++ b/icc-x-api/index.ts
@@ -227,9 +227,98 @@ namespace IcureApiOptions {
 
 /**
  * Specifies which fields should be encrypted for each kind of encryptable entity.
+ *
  * Note that any value you specify here overrides the default values. For example if you specify `['medicalLocationId']` for `healthElement` the
  * fields `['descr', 'note']` which are usually encrypted by default will no longer be encrypted. If you want to add fields to the default values
  * you can use {@link EncryptedFieldsConfig.Defaults}, for example `[...EncryptedFieldsConfig.Defaults.healthElement, 'medicalLocationId'].
+ *
+ * # Encrypted fields syntax
+ *
+ * ## Grammar
+ *
+ * The grammar for each encrypted field is the following:
+ * ```
+ * fieldName :=
+ *   regex([a-zA-Z_][a-zA-Z0-9_]+)
+ * encryptedField :=
+ *   fieldName
+ *   | fieldName + ("." | ".*." | "[].") + encryptedField
+ * ```
+ *
+ * This grammar allows you to specify the fields to encrypt for the object and recursively for nested objects.
+ * - A string containing only a single `fieldName` will encrypt the field with the given name.
+ * - A string starting with `fieldName.` allows to specify the encrypted fields of a nested object. The encrypted values of the
+ *   fields in the nested object will be saved in the nested object.
+ * - A string starting with `fieldName.*.` treats `fieldName` as a map/dictionary data structure and allows to specify the encrypted fields of the
+ *   values of the map. Note that the values of the map must be objects as well. The encrypted content of each map value is stored in that value.
+ * - A string starting with `fieldName[].` treats `fieldName` as an array and allows to specify the encrypted fields of the values of the array.
+ *   Note that the values of the array must be objects as well. The encrypted content of each array element is stored in that element.
+ *
+ * ## Example
+ *
+ * Consider the following object and encryption keys:
+ * ```javascript
+ * const obj = {
+ *   a: { x: 0, y: 1 },
+ *   b: "hello",
+ *   c: [ { public: "a", secret: "b" }, { public: "c", secret: "d" } ],
+ *   d: "ok",
+ *   e: {
+ *     info: "something",
+ *     private: "secret",
+ *     dataMap: {
+ *       "en": {
+ *         a: 1,
+ *         b: 2
+ *       },
+ *       "fr": {
+ *         a: 3,
+ *         b: 4
+ *       }
+ *     }
+ *   }
+ * }
+ * const encryptedFields = [
+ *   "a",
+ *   "c[].secret",
+ *   "d",
+ *   "e.private",
+ *   "e.datamap.*.a"
+ * ]
+ * ```
+ * If you use them with the crypt method you will get the following result:
+ * ```json
+ * {
+ *   b: "hello",
+ *   c: [
+ *     { public: "a", encryptedSelf: "...encrypted data of c[0]" },
+ *     { public: "c", encryptedSelf: "...encrypted data of c[1]" }
+ *   ],
+ *   e: {
+ *     info: "something",
+ *     dataMap: {
+ *       "en": { b: 2, encryptedSelf: "...encrypted data of e.dataMap['en']" },
+ *       "fr": { b: 4, encryptedSelf: "...encrypted data of e.dataMap['fr']" }
+ *     },
+ *     encryptedSelf: "...encrypted data of e"
+ *   },
+ *   encryptedSelf: "...encrypted data of obj"
+ * }
+ * ```
+ *
+ * ## Shortened representation
+ *
+ * You can also group encrypted fields having the same prefix by concatenating to the prefix the JSON representation of an array of all the postfixes.
+ * For example the following encrypted fields:
+ * ```javascript
+ * const encryptedFields = ["a.b.c.d.e.f1", "a.b.c.d.e.f2", "a.b.c.d.e.f3", "a.b.c.d.e.f4"]
+ * ```
+ * can be shortened to
+ * ```javascript
+ * const encryptedFields = ['a.b.c.d.e.["f1","f2","f3","f4"]'] // Note the use of single quotes to avoid escaping the double quotes
+ * ```
+ * If you use the shortened representation you may need to escape nested json representations. In that case the use of `JSON.stringify` is
+ * recommended.
  */
 export interface EncryptedFieldsConfig {
   /**

--- a/icc-x-api/index.ts
+++ b/icc-x-api/index.ts
@@ -242,10 +242,18 @@ export interface EncryptedFieldsConfig {
    * @default ['details', 'title', 'patientId']
    */
   readonly calendarItem?: string[]
-  /*TODO
-   * configuration not yet supported for contact; automatically applies to descr and content of services
+  /**
+   * Fields to encrypt for entities of type {@link Contact}, excluding `services`. You can specify which fields of `services` should be encrypted
+   * using {@link service}.
+   * @default ['descr'] // encryption of `services` is managed through {@link service}
    */
-  // readonly contact?: string[]
+  readonly contact?: string[]
+  /**
+   * Fields to encrypt for entities of type {@link Service}. Note that encryption of the `content` field and recursively contained `Services` through
+   * `content.compoundValue` is automatically managed by the sdk, and you are not allowed to modify it.
+   * @default [] // encryption of `content` is managed in a special way
+   */
+  readonly service?: string[]
   /**
    * Fields to encrypt for entities of type {@link HealthElement}
    * @default ['descr', 'note']
@@ -266,7 +274,8 @@ export namespace EncryptedFieldsConfig {
   export const Defaults = {
     accessLog: ['detail', 'objectId'],
     calendarItem: ['details', 'title', 'patientId'],
-    // TODO contact
+    contact: ['descr'],
+    service: [],
     healthElement: ['descr', 'note'],
     maintenanceTask: ['properties'],
     patient: ['note'],
@@ -644,7 +653,9 @@ class IcureApiImpl implements IcureApi {
         this.cryptoApi,
         this.dataOwnerApi,
         this.groupSpecificAuthenticationProvider,
-        this.fetch
+        this.fetch,
+        this.params.encryptedFieldsConfig.contact ?? EncryptedFieldsConfig.Defaults.contact,
+        this.params.encryptedFieldsConfig.service ?? EncryptedFieldsConfig.Defaults.service
       ))
     )
   }

--- a/icc-x-api/utils/crypto-utils.ts
+++ b/icc-x-api/utils/crypto-utils.ts
@@ -484,8 +484,9 @@ export async function decrypt(
 ): Promise<{ [key: string]: any }> {
   const copy: { [key: string]: any } = {}
   for (const [key, value] of Object.entries(obj)) {
-    if (key === 'encryptedSelf') continue
-    if (typeof value === 'object' && value !== null) {
+    if (key === 'encryptedSelf') {
+      copy[key] = value
+    } else if (typeof value === 'object' && value !== null) {
       if (Array.isArray(value)) {
         // Note: nested arrays (and primitives) are returned as is and not they are not recursively decrypted. This is because we currently do not
         // support encryption of elements from arrays in arrays (we only support arrays in objects in arrays). In future this may change.

--- a/icc-x-api/utils/crypto-utils.ts
+++ b/icc-x-api/utils/crypto-utils.ts
@@ -185,56 +185,322 @@ function moment(epochOrLongCalendar: number): Moment | null {
 }
 
 /**
- * Encrypt object graph recursively
- *
- * @param obj the object to encrypt
- * @param cryptor the cryptor function (returns a promise)
- * @param keys the keys to be crypted: ex for a Patient ['note', 'addresses.*.["street", "houseNumber", "telecoms.*.telecomNumber"]']
+ * Configuration for the encryption of an object.
+ * @param topLevelFields the fields of the object to encrypt. All the fields will be encrypted in a single encryptedSelf field which is added to the
+ * object.
+ * @param nestedObjectsKeys the name of fields which are expected to contain a nested object (or undefined). Allows to specify
  */
-export async function crypt(obj: any, cryptor: (obj: { [key: string]: string }) => Promise<ArrayBuffer>, keys: Array<string>) {
-  const subObj = _.pick(
-    obj,
-    keys.filter((k) => !k.includes('*'))
-  )
-  obj.encryptedSelf = b2a(ua2string(await cryptor(subObj)))
-  Object.keys(subObj).forEach((k) => delete obj[k])
-
-  await keys
-    .filter((k) => k.includes('*'))
-    .reduce(async (prev: Promise<void>, k: any) => {
-      await prev
-      const k1 = k.split('.*.')[0]
-      const k2 = k.substr(k1.length + 3)
-
-      const mapped = await Promise.all((_.get(obj, k1) || []).map((so: any) => crypt(so, cryptor, k2.startsWith('[') ? JSON.parse(k2) : [k2])))
-      _.set(obj, k1, mapped)
-    }, Promise.resolve())
-
-  return obj
+export type EncryptedFieldsKeys = {
+  topLevelFields: { fieldName: string; fieldPath: string }[]
+  nestedObjectsKeys: {
+    [objectFieldName: string]: EncryptedFieldsKeys
+  }
+  mapsValuesKeys: {
+    [mapFieldName: string]: EncryptedFieldsKeys
+  }
+  arraysValuesKeys: {
+    [arrayFieldName: string]: EncryptedFieldsKeys
+  }
 }
 
 /**
- * Decrypt object graph recursively
+ * @internal this function is for internal use only and may be changed without notice
  *
- * @param obj the object to encrypt
- * @param decryptor the decryptor function (returns a promise)
+ * Parse the encrypted fields configuration for a specific entity type.
+ *
+ * ## Grammar
+ *
+ * The grammar for each encrypted field is the following:
+ * ```
+ * fieldName :=
+ *   regex([a-zA-Z_][a-zA-Z0-9_]+)
+ * encryptedField :=
+ *   fieldName
+ *   | fieldName + ("." | ".*." | "[].") + encryptedField
+ * ```
+ *
+ * This grammar allows you to specify the fields to encrypt for the object and recursively for nested objects.
+ * - A string containing only a single `fieldName` will encrypt the field with the given name.
+ * - A string starting with `fieldName.` allows to specify the encrypted fields of a nested object. The encrypted values of the
+ *   fields in the nested object will be saved in the nested object.
+ * - A string starting with `fieldName.*.` treats `fieldName` as a map/dictionary data structure and allows to specify the encrypted fields of the
+ *   values of the map. Note that the values of the map must be objects as well. The encrypted content of each map value is stored in that value.
+ * - A string starting with `fieldName[].` treats `fieldName` as an array and allows to specify the encrypted fields of the values of the array.
+ *   Note that the values of the array must be objects as well. The encrypted content of each array element is stored in that element.
+ * - You can specify multiple layers of recursion.
+ *
+ * ## Example
+ *
+ * Consider the following object and encryption keys:
+ * ```javascript
+ * const obj = {
+ *   a: { x: 0, y: 1 },
+ *   b: "hello",
+ *   c: [ { public: "a", secret: "b" }, { public: "c", secret: "d" } ],
+ *   d: "ok",
+ *   e: {
+ *     info: "something",
+ *     private: "secret",
+ *     dataMap: {
+ *       "en": {
+ *         a: 1,
+ *         b: 2
+ *       },
+ *       "fr": {
+ *         a: 3,
+ *         b: 4
+ *       }
+ *     }
+ *   }
+ * }
+ * const encryptedFields = [
+ *   "a",
+ *   "c[].secret",
+ *   "d",
+ *   "e.private",
+ *   "e.datamap.*.a"
+ * ]
+ * ```
+ * If you use them with the crypt method you will get the following result:
+ * ```json
+ * {
+ *   b: "hello",
+ *   c: [
+ *     { public: "a", encryptedSelf: "...encrypted data of c[0]" },
+ *     { public: "c", encryptedSelf: "...encrypted data of c[1]" }
+ *   ],
+ *   e: {
+ *     info: "something",
+ *     dataMap: {
+ *       "en": { b: 2, encryptedSelf: "...encrypted data of e.dataMap['en']" },
+ *       "fr": { b: 4, encryptedSelf: "...encrypted data of e.dataMap['fr']" }
+ *     },
+ *     encryptedSelf: "...encrypted data of e"
+ *   },
+ *   encryptedSelf: "...encrypted data of obj"
+ * }
+ * ```
+ *
+ * ## Shortened representation
+ *
+ * You can also group encrypted fields having the same prefix by concatenating to the prefix the JSON representation of an array of all the postfixes.
+ * For example the following encrypted fields:
+ * ```javascript
+ * const encryptedFields = ["a.b.c.d.e.f1", "a.b.c.d.e.f2", "a.b.c.d.e.f3", "a.b.c.d.e.f4"]
+ * ```
+ * can be shortened to
+ * ```javascript
+ * const encryptedFields = ['a.b.c.d.e.["f1","f2","f3","f4"]'] // Note the use of single quotes to avoid escaping the double quotes
+ * ```
+ * If you use the shortened representation you may need to escape nested json representations. In that case the use of `JSON.stringify` is
+ * recommended.
+ *
+ * @param encryptedFields
+ * @param path
  */
-export async function decrypt(obj: any, decryptor: (obj: Uint8Array) => Promise<{ [key: string]: string }>) {
-  await Object.keys(obj).reduce(async (prev: Promise<void>, k: any) => {
-    await prev
-    if (Array.isArray(obj[k])) {
-      await (obj[k] as Array<any>)
-        .filter((o) => typeof o === 'object' && o !== null)
-        .reduce(async (prev: Promise<void>, so: any) => {
-          await prev
-          await decrypt(so, decryptor)
-        }, Promise.resolve())
-    }
-  }, Promise.resolve())
-  if (obj.encryptedSelf) {
-    Object.assign(obj, await decryptor(string2ua(a2b(obj.encryptedSelf))))
+export function parseEncryptedFields(encryptedFields: string[], path: string): EncryptedFieldsKeys {
+  const groupedData = {
+    topLevelFields: new Set<string>(),
+    nestedObjectsKeys: {} as { [objectFieldName: string]: string[] },
+    mapsValuesKeys: {} as { [mapFieldName: string]: string[] },
+    arraysValuesKeys: {} as { [arrayFieldName: string]: string[] },
   }
-  return obj
+  const encryptedFieldRegex = /^([_a-zA-Z][_a-zA-Z0-9]*)(?:(\.\*\.|\[]\.|\.)(?:[_a-zA-Z].*|\[.*]))?$/
+  const addSubkeyToGroupedData = (
+    currFieldName: string,
+    currFieldSeparator: string,
+    currEncryptedField: string,
+    groupedDataKey: 'nestedObjectsKeys' | 'mapsValuesKeys' | 'arraysValuesKeys'
+  ) => {
+    const existingOrNew = groupedData[groupedDataKey][currFieldName] ?? (groupedData[groupedDataKey][currFieldName] = [])
+    const subKey = currEncryptedField.slice(currFieldName.length + currFieldSeparator.length)
+    if (subKey.startsWith('[')) {
+      let parsedJson: any[]
+      try {
+        parsedJson = JSON.parse(subKey)
+      } catch {
+        throw new Error(`Invalid encrypted field ${path}${currEncryptedField} (not a valid JSON subkey)`)
+      }
+      if (Array.isArray(parsedJson) && parsedJson.every((x) => typeof x == 'string')) {
+        parsedJson.forEach((x) => existingOrNew.push(x))
+      } else throw new Error(`Invalid encrypted field ${path}${currEncryptedField} (not an array of strings)`)
+    } else {
+      existingOrNew.push(subKey)
+    }
+  }
+  for (const currEncryptedField of encryptedFields) {
+    const currFieldMatch = currEncryptedField.match(encryptedFieldRegex)
+    if (!!currFieldMatch) {
+      const currFieldName = currFieldMatch[1]
+      const currFieldSeparator = currFieldMatch[2]
+      if (!currFieldSeparator) {
+        if (groupedData.topLevelFields.has(currFieldName)) throw new Error(`Duplicate encrypted field ${path}${currFieldName}`)
+        if (
+          !!groupedData.nestedObjectsKeys[currFieldName] ||
+          !!groupedData.mapsValuesKeys[currFieldName] ||
+          !!groupedData.arraysValuesKeys[currFieldName]
+        )
+          throw new Error(`Encrypted field appears multiple times as different nested types and or top-level-field: ${path}${currFieldName}`)
+        groupedData.topLevelFields.add(currFieldName)
+      } else if (currFieldSeparator == '.') {
+        if (
+          groupedData.topLevelFields.has(currFieldName) ||
+          !!groupedData.mapsValuesKeys[currFieldName] ||
+          !!groupedData.arraysValuesKeys[currFieldName]
+        )
+          throw new Error(`Encrypted field appears multiple times as different nested types and or top-level-field: ${path}${currFieldName}`)
+        addSubkeyToGroupedData(currFieldName, currFieldSeparator, currEncryptedField, 'nestedObjectsKeys')
+      } else if (currFieldSeparator == '.*.') {
+        if (
+          groupedData.topLevelFields.has(currFieldName) ||
+          !!groupedData.nestedObjectsKeys[currFieldName] ||
+          !!groupedData.arraysValuesKeys[currFieldName]
+        )
+          throw new Error(`Encrypted field appears multiple times as different nested types and or top-level-field: ${path}${currFieldName}`)
+        addSubkeyToGroupedData(currFieldName, currFieldSeparator, currEncryptedField, 'mapsValuesKeys')
+      } else if (currFieldSeparator == '[].') {
+        if (
+          groupedData.topLevelFields.has(currFieldName) ||
+          !!groupedData.nestedObjectsKeys[currFieldName] ||
+          !!groupedData.mapsValuesKeys[currFieldName]
+        )
+          throw new Error(`Encrypted field appears multiple times as different nested types and or top-level-field: ${path}${currFieldName}`)
+        addSubkeyToGroupedData(currFieldName, currFieldSeparator, currEncryptedField, 'arraysValuesKeys')
+      } else throw new Error(`Internal error: unknown separator ${currFieldSeparator} passed regex validation in ${path}${currEncryptedField}`)
+    } else throw new Error(`Invalid encrypted field ${path}${currEncryptedField}`)
+  }
+  return {
+    topLevelFields: Array.from(groupedData.topLevelFields).map((fieldName) => ({ fieldName, fieldPath: path + fieldName })),
+    nestedObjectsKeys: Object.fromEntries(
+      Object.entries(groupedData.nestedObjectsKeys).map(([fieldName, fieldNames]) => [
+        fieldName,
+        parseEncryptedFields(fieldNames, path + fieldName + '.'),
+      ])
+    ),
+    mapsValuesKeys: Object.fromEntries(
+      Object.entries(groupedData.mapsValuesKeys).map(([fieldName, fieldNames]) => [
+        fieldName,
+        parseEncryptedFields(fieldNames, path + fieldName + '.*.'),
+      ])
+    ),
+    arraysValuesKeys: Object.fromEntries(
+      Object.entries(groupedData.arraysValuesKeys).map(([fieldName, fieldNames]) => [
+        fieldName,
+        parseEncryptedFields(fieldNames, path + fieldName + '[].'),
+      ])
+    ),
+  }
+}
+
+/**
+ * @internal this function is for internal use only and may be changed without notice
+ * Encrypt the object graph recursively. Generally return an updated SHALLOW copy, although some fields may be deep copied if they also needed to be
+ * recursively encrypted.
+ * @param obj the object to encrypt
+ * @param cryptor takes in input an object consisting only of the fields to encrypt of obj, and returns the encrypted object.
+ * @param keys the keys to encrypt for the
+ * @param path path of the current object, used for error messages.
+ * @return a shallow copy of the object with a new encryptedSelfField and without the encrypted fields.
+ */
+export async function crypt(
+  obj: { [key: string]: any },
+  cryptor: (obj: { [key: string]: any }) => Promise<ArrayBuffer>,
+  keys: EncryptedFieldsKeys,
+  path: string = 'obj'
+): Promise<{ [key: string]: any }> {
+  const shallowClone = { ...obj }
+  const currEncryptedFields: { [key: string]: any } = {}
+  for (const { fieldName } of keys.topLevelFields) {
+    const fieldValue = shallowClone[fieldName]
+    if (fieldValue !== undefined) {
+      // we keep null values
+      currEncryptedFields[fieldName] = fieldValue
+      delete shallowClone[fieldName]
+    }
+  }
+  shallowClone['encryptedSelf'] = b2a(ua2string(await cryptor(currEncryptedFields)))
+  for (const [fieldName, subKeys] of Object.entries(keys.nestedObjectsKeys)) {
+    const fieldValue = shallowClone[fieldName]
+    if (fieldValue !== undefined && fieldValue !== null) {
+      if (!isPojo(fieldValue)) throw new Error(`Expected field ${path}.${fieldName} to be a non-array object`)
+      shallowClone[fieldName] = await crypt(fieldValue, cryptor, subKeys, path + '.' + fieldName)
+    }
+  }
+  for (const [mapFieldName, subKeys] of Object.entries(keys.mapsValuesKeys)) {
+    const fieldValue = shallowClone[mapFieldName]
+    if (fieldValue !== undefined && fieldValue !== null) {
+      if (!isPojo(fieldValue)) throw new Error(`Expected field ${path}.${mapFieldName} to be a non-array object`)
+      const newMap: { [key: string]: any } = {}
+      for (const [key, value] of Object.entries(fieldValue as object)) {
+        if (value === null || value === undefined) {
+          newMap[key] = value
+        } else {
+          if (!isPojo(value)) throw new Error(`Expected field ${path}.${mapFieldName}.${key} to be a non-array object`)
+          newMap[key] = await crypt(value, cryptor, subKeys, path + '.' + mapFieldName + '.' + key)
+        }
+      }
+      shallowClone[mapFieldName] = newMap
+    }
+  }
+  for (const [arrayFieldName, subKeys] of Object.entries(keys.arraysValuesKeys)) {
+    const fieldValue = shallowClone[arrayFieldName]
+    if (fieldValue !== undefined && fieldValue !== null) {
+      if (!Array.isArray(fieldValue)) throw new Error(`Expected field ${path}.${arrayFieldName} to be an array`)
+      const newArray: any[] = Array(fieldValue.length)
+      for (let i = 0; i < fieldValue.length; i++) {
+        const value = fieldValue[i]
+        if (value === null || value === undefined) {
+          newArray[i] = value
+        } else {
+          if (!isPojo(value)) throw new Error(`Expected field ${path}.${arrayFieldName}[${i}] to be a non-array object`)
+          newArray[i] = await crypt(value, cryptor, subKeys, path + '.' + arrayFieldName + '[' + i + ']')
+        }
+      }
+      shallowClone[arrayFieldName] = newArray
+    }
+  }
+  return shallowClone
+}
+
+/**
+ * Check if value is a non-null object that is not an array.
+ */
+function isPojo(value: any): boolean {
+  // This break if for some reason we have object versions of String/Number/Boolean
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+/**
+ * @internal this function is for internal use only and may be changed without notice
+ * Decrypt object graph recursively.
+ *
+ * @param obj the object to decrypt
+ * @param decryptor the decryptor function (returns a promise)
+ * @return a deep copy of the object with the decrypted fields and removed encryptedSelf field
+ */
+export async function decrypt(
+  obj: { [key: string]: any },
+  decryptor: (obj: Uint8Array) => Promise<{ [key: string]: any }>
+): Promise<{ [key: string]: any }> {
+  const copy: { [key: string]: any } = {}
+  for (const [key, value] of Object.entries(obj)) {
+    if (key === 'encryptedSelf') continue
+    if (typeof value === 'object' && value !== null) {
+      if (Array.isArray(value)) {
+        // Note: nested arrays (and primitives) are returned as is and not they are not recursively decrypted. This is because we currently do not
+        // support encryption of elements from arrays in arrays (we only support arrays in objects in arrays). In future this may change.
+        copy[key] = await Promise.all(value.map((v) => (isPojo(v) ? decrypt(v, decryptor) : v)))
+      } else {
+        copy[key] = await decrypt(value, decryptor)
+      }
+    } else {
+      copy[key] = value
+    }
+  }
+  if (obj.encryptedSelf) {
+    const decrypted = await decryptor(string2ua(a2b(obj.encryptedSelf)))
+    return { ...copy, ...decrypted }
+  } else return copy
 }
 
 /**

--- a/test/icc-x-api/crypto/full-crypto-test.ts
+++ b/test/icc-x-api/crypto/full-crypto-test.ts
@@ -56,16 +56,14 @@ const facades: EntityFacades = {
     share: async (api, p, r, doId) => {
       const user = await api.userApi.getCurrentUser()
       const ownerId = api.dataOwnerApi.getDataOwnerIdOf(user)
-      return api.patientApi.modifyPatientWithUser(
-        await api.userApi.getCurrentUser(),
-        await api.cryptoApi.entities.entityWithExtendedEncryptedMetadata(
-          r,
-          doId,
-          await api.cryptoApi.entities.secretIdsOf(r),
-          await api.cryptoApi.entities.encryptionKeysOf(r),
-          p ? [p.id!] : []
-        )
+      const shared = await api.cryptoApi.entities.entityWithExtendedEncryptedMetadata(
+        r,
+        doId,
+        await api.cryptoApi.entities.secretIdsOf(r),
+        await api.cryptoApi.entities.encryptionKeysOf(r),
+        p ? [p.id!] : []
       )
+      return shared ? api.patientApi.modifyPatientWithUser(await api.userApi.getCurrentUser(), shared) : r
     },
     isDecrypted: async (entityToCheck) => {
       return entityToCheck.note != undefined
@@ -77,16 +75,14 @@ const facades: EntityFacades = {
     share: async (api, p, r, doId) => {
       const user = await api.userApi.getCurrentUser()
       const ownerId = api.dataOwnerApi.getDataOwnerIdOf(user)
-      return api.contactApi.modifyContactWithUser(
-        await api.userApi.getCurrentUser(),
-        await api.cryptoApi.entities.entityWithExtendedEncryptedMetadata(
-          r,
-          doId,
-          await api.cryptoApi.entities.secretIdsOf(r),
-          await api.cryptoApi.entities.encryptionKeysOf(r),
-          p ? [p.id!] : []
-        )
+      const shared = await api.cryptoApi.entities.entityWithExtendedEncryptedMetadata(
+        r,
+        doId,
+        await api.cryptoApi.entities.secretIdsOf(r),
+        await api.cryptoApi.entities.encryptionKeysOf(r),
+        p ? [p.id!] : []
       )
+      return shared ? api.contactApi.modifyContactWithUser(await api.userApi.getCurrentUser(), shared) : r
     },
     isDecrypted: async (entityToCheck) => {
       return entityToCheck.services?.[0].content != undefined && Object.entries(entityToCheck.services?.[0].content).length > 0
@@ -98,16 +94,14 @@ const facades: EntityFacades = {
     share: async (api, p, r, doId) => {
       const user = await api.userApi.getCurrentUser()
       const ownerId = api.dataOwnerApi.getDataOwnerIdOf(user)
-      return api.healthcareElementApi.modifyHealthElementWithUser(
-        await api.userApi.getCurrentUser(),
-        await api.cryptoApi.entities.entityWithExtendedEncryptedMetadata(
-          r,
-          doId,
-          await api.cryptoApi.entities.secretIdsOf(r),
-          await api.cryptoApi.entities.encryptionKeysOf(r),
-          p ? [p.id!] : []
-        )
+      const shared = await api.cryptoApi.entities.entityWithExtendedEncryptedMetadata(
+        r,
+        doId,
+        await api.cryptoApi.entities.secretIdsOf(r),
+        await api.cryptoApi.entities.encryptionKeysOf(r),
+        p ? [p.id!] : []
       )
+      return shared ? api.healthcareElementApi.modifyHealthElementWithUser(await api.userApi.getCurrentUser(), shared) : r
     },
     isDecrypted: async (entityToCheck) => {
       return entityToCheck.descr != undefined
@@ -119,16 +113,14 @@ const facades: EntityFacades = {
     share: async (api, p, r, doId) => {
       const user = await api.userApi.getCurrentUser()
       const ownerId = api.dataOwnerApi.getDataOwnerIdOf(user)
-      return api.calendarItemApi.modifyCalendarItemWithHcParty(
-        await api.userApi.getCurrentUser(),
-        await api.cryptoApi.entities.entityWithExtendedEncryptedMetadata(
-          r,
-          doId,
-          await api.cryptoApi.entities.secretIdsOf(r),
-          await api.cryptoApi.entities.encryptionKeysOf(r),
-          p ? [p.id!] : []
-        )
+      const shared = await api.cryptoApi.entities.entityWithExtendedEncryptedMetadata(
+        r,
+        doId,
+        await api.cryptoApi.entities.secretIdsOf(r),
+        await api.cryptoApi.entities.encryptionKeysOf(r),
+        p ? [p.id!] : []
       )
+      return shared ? api.calendarItemApi.modifyCalendarItemWithHcParty(await api.userApi.getCurrentUser(), shared) : r
     },
     isDecrypted: async (entityToCheck) => {
       return entityToCheck.title != undefined
@@ -575,7 +567,8 @@ describe('Full crypto test - Read/Share scenarios', async function () {
                     ? await api.patientApi.getPatientWithUser(user, user.patientId!)
                     : await api.patientApi.getPatientWithUser(user, `${user.id}-Patient`)
                   : undefined
-              const entity = await facade.share(api, parent, await facade.get(api, `${user.id}-${f[0]}`), delegateDoId)
+              const retrievedEntity = await facade.get(api, `${user.id}-${f[0]}`)
+              const entity = await facade.share(api, parent, retrievedEntity, delegateDoId)
               const retrieved = await facade.get(api, entity.id)
               expect(entity.rev).to.equal(retrieved.rev)
               expect(Object.keys(entity.delegations)).to.contain(delegateDoId)

--- a/test/icc-x-api/crypto/share-to-newly-created-patient-from-hcp.ts
+++ b/test/icc-x-api/crypto/share-to-newly-created-patient-from-hcp.ts
@@ -14,6 +14,7 @@ import { TestKeyStorage, TestStorage } from '../../utils/TestStorage'
 import { TestCryptoStrategies } from '../../utils/TestCryptoStrategies'
 import { getEnvVariables, TestVars } from '@icure/test-setup/types'
 import { IcureApi } from '../../../icc-x-api'
+import exp = require('constants')
 
 setLocalStorage(fetch)
 
@@ -68,7 +69,11 @@ describe('Full battery of tests on crypto and keys', async function () {
 
     expect(pat.note ?? undefined).to.be.undefined
 
-    await api.patientApi.share(u, patient.id, u.healthcarePartyId!, [patient.id], { [patient.id]: ['all'] })
+    const shareResult = await api.patientApi.share(u, patient.id, u.healthcarePartyId!, [patient.id], { [patient.id]: ['all'] })
+    expect(shareResult).to.not.be.null
+    expect(shareResult!.patient).to.not.be.null
+    expect(shareResult!.patient!.rev).to.not.equal(pat.rev, 'Patient should have been updated')
+    expect(shareResult!.statuses.healthElements?.success).to.be.true
     await apiAsPatient.cryptoApi.forceReload()
     const patUser = await apiAsPatient.userApi.getCurrentUser()
     const entity = await apiAsPatient.patientApi.getPatientWithUser(patUser, patient.id)

--- a/test/icc-x-api/data-compatibility-test-7to6.ts
+++ b/test/icc-x-api/data-compatibility-test-7to6.ts
@@ -1,0 +1,401 @@
+import { getEnvVariables, TestVars } from '@icure/test-setup/types'
+import { before } from 'mocha'
+import { getEnvironmentInitializer, hcp1Username, setLocalStorage, TestUtils } from '../utils/test_utils'
+import * as _ from 'lodash'
+import { Api as initApiV6, Apis as ApisV6, IccPatientXApi as IccPatientXApiV6, User as UserV6 } from '@icure/apiV6'
+import { hex2ua, IcureApi } from '../../icc-x-api'
+import { webcrypto } from 'crypto'
+import { TestKeyStorage, TestStorage } from '../utils/TestStorage'
+import { TestCryptoStrategies } from '../utils/TestCryptoStrategies'
+import { IccAccesslogApi, IccCalendarItemApi, IccContactApi, IccHelementApi, IccPatientApi } from '../../icc-api'
+import { expect } from 'chai'
+import { User } from '../../icc-api/model/User'
+import 'isomorphic-fetch'
+import { IccMaintenanceTaskApi } from '../../icc-api/api/IccMaintenanceTaskApi'
+
+setLocalStorage(fetch)
+
+let env: TestVars
+let apiV6: ApisV6
+let apiV7: IcureApi
+let userV6: UserV6
+let userV7: User
+let patient: any
+
+describe('iCure API v6 and v7 (current) should be fully data compatible', async () => {
+  before(async function () {
+    this.timeout(600000)
+    const initializer = await getEnvironmentInitializer()
+    env = await initializer.execute(getEnvVariables())
+    apiV6 = await initApiV6(
+      env.iCureUrl + '/rest/v1',
+      env.dataOwnerDetails[hcp1Username].user,
+      env.dataOwnerDetails[hcp1Username].password,
+      webcrypto as any,
+      fetch,
+      false,
+      false,
+      new TestStorage(),
+      new TestKeyStorage()
+    )
+    await apiV6.cryptoApi.loadKeyPairsAsTextInBrowserLocalStorage(
+      env.dataOwnerDetails[hcp1Username].dataOwnerId,
+      hex2ua(env.dataOwnerDetails[hcp1Username].privateKey)
+    )
+    apiV6.patientApi = new IccPatientXApiV6( // Want to override encryption keys
+      env.iCureUrl + '/rest/v1',
+      {},
+      apiV6.cryptoApi,
+      apiV6.contactApi,
+      apiV6.formApi,
+      apiV6.healthcareElementApi,
+      apiV6.invoiceApi,
+      apiV6.documentApi,
+      apiV6.healthcarePartyApi,
+      apiV6.classificationApi,
+      apiV6.dataOwnerApi,
+      apiV6.calendarItemApi,
+      ['note', 'properties.*.typedValue'],
+      apiV6.authApi.authenticationProvider,
+      fetch
+    )
+    apiV7 = await IcureApi.initialise(
+      env.iCureUrl,
+      { username: env.dataOwnerDetails[hcp1Username].user, password: env.dataOwnerDetails[hcp1Username].password },
+      new TestCryptoStrategies({
+        publicKey: await apiV6.cryptoApi.RSA.importKey('spki', hex2ua(env.dataOwnerDetails[hcp1Username].publicKey), ['encrypt']),
+        privateKey: await apiV6.cryptoApi.RSA.importKey('pkcs8', hex2ua(env.dataOwnerDetails[hcp1Username].privateKey), ['decrypt']),
+      }),
+      webcrypto as any,
+      fetch,
+      {
+        storage: new TestStorage(),
+        keyStorage: new TestKeyStorage(),
+        encryptedFieldsConfig: {
+          patient: ['note', 'properties[].typedValue'],
+        },
+      }
+    )
+    userV6 = await apiV6.userApi.getCurrentUser()
+    userV7 = await apiV7.userApi.getCurrentUser()
+    patient = await apiV6.patientApi.createPatientWithUser(userV6, await apiV6.patientApi.newInstance(userV6, { firstName: 'Joe', lastName: 'Dhon' }))
+  })
+
+  it('An AccessLog created from V6 should be readable from v7 and vice versa, and the structure of their encrypted data should be equivalent.', async () => {
+    const baseApi = new IccAccesslogApi(env.iCureUrl, {}, apiV7.authApi.authenticationProvider, fetch)
+    const accessLogData = {
+      detail: 'secret',
+      objectId: 'secret2',
+      medicalLocationId: 'notSecret',
+    }
+    const createdV6 = await apiV6.accessLogApi.createAccessLogWithUser(
+      userV6,
+      await apiV6.accessLogApi.newInstance(userV6, patient, _.cloneDeep(accessLogData))
+    )
+    const createdV7 = await apiV7.accessLogApi.createAccessLogWithUser(
+      userV7,
+      await apiV7.accessLogApi.newInstance(userV7, patient, _.cloneDeep(accessLogData))
+    )
+    ;[
+      await apiV6.accessLogApi.getAccessLogWithUser(userV6, createdV7.id), // Read V7 from V6,
+      await apiV7.accessLogApi.getAccessLogWithUser(userV7, createdV6.id), // Read V6 from V7
+    ].forEach((decrypted) => {
+      expect(decrypted.medicalLocationId).to.equal(accessLogData.medicalLocationId)
+      expect(decrypted.detail).to.equal(accessLogData.detail)
+      expect(decrypted.objectId).to.equal(accessLogData.objectId)
+    })
+    const encryptedV6 = await baseApi.getAccessLog(createdV6.id)
+    const encryptedV7 = await baseApi.getAccessLog(createdV7.id)
+    ;[encryptedV6, encryptedV7].forEach((encrypted) => {
+      expect(encrypted.detail).to.be.undefined
+      expect(encrypted.objectId).to.be.undefined
+      expect(encrypted.medicalLocationId).to.equal(accessLogData.medicalLocationId)
+      expect(encrypted.encryptedSelf).to.not.be.undefined
+    })
+    expect(encryptedV6.encryptedSelf!.length).to.equal(encryptedV7.encryptedSelf!.length)
+  })
+
+  it('A CalendarItem created from V6 should be readable from v7 and vice versa, and the structure of their encrypted data should be equivalent.', async () => {
+    const baseApi = new IccCalendarItemApi(env.iCureUrl, {}, apiV7.authApi.authenticationProvider, fetch)
+    const calendarItemData = {
+      patientId: apiV7.cryptoApi.primitives.randomUuid(),
+      details: 'Hello',
+      placeId: '123',
+    }
+    const createdV6 = await apiV6.calendarItemApi.createCalendarItemWithHcParty(
+      userV6,
+      await apiV6.calendarItemApi.newInstance(userV6, _.cloneDeep(calendarItemData))
+    )
+    const createdV7 = await apiV7.calendarItemApi.createCalendarItemWithHcParty(
+      userV7,
+      await apiV7.calendarItemApi.newInstance(userV7, _.cloneDeep(calendarItemData))
+    )
+    ;[
+      await apiV6.calendarItemApi.getCalendarItemWithUser(userV6, createdV7.id), // Read V7 from V6,
+      await apiV7.calendarItemApi.getCalendarItemWithUser(userV7, createdV6.id), // Read V6 from V7
+    ].forEach((decrypted) => {
+      expect(decrypted.patientId).to.equal(calendarItemData.patientId)
+      expect(decrypted.details).to.equal(calendarItemData.details)
+      expect(decrypted.placeId).to.equal(calendarItemData.placeId)
+    })
+    const encryptedV6 = await baseApi.getCalendarItem(createdV6.id)
+    const encryptedV7 = await baseApi.getCalendarItem(createdV7.id)
+    ;[encryptedV6, encryptedV7].forEach((encrypted) => {
+      expect(encrypted.placeId).to.equal(calendarItemData.placeId)
+      expect(encrypted.details).to.be.undefined
+      expect(encrypted.patientId).to.be.undefined
+      expect(encrypted.encryptedSelf).to.not.be.undefined
+    })
+    expect(encryptedV6.encryptedSelf!.length).to.equal(encryptedV7.encryptedSelf!.length)
+  })
+
+  it('A Contact created from V6 should be readable from v7 and vice versa, and the structure of their encrypted data should be equivalent.', async () => {
+    const baseApi = new IccContactApi(env.iCureUrl, {}, apiV7.authApi.authenticationProvider, fetch)
+    const contactData = {
+      descr: 'secret',
+      location: 'notSecret',
+      services: [
+        {
+          id: 'flat',
+          label: 'notSecret1',
+          comment: 'notSecret2',
+          content: { fr: { stringValue: 'Salut' }, nl: { stringValue: 'Halo' } },
+        },
+        {
+          id: 'compound',
+          content: {
+            fr: {
+              compoundValue: [
+                {
+                  id: 'nested1',
+                  label: 'notSecret3',
+                  comment: 'notSecret4',
+                  content: { fr: { stringValue: 'A' } },
+                },
+                {
+                  id: 'nested2',
+                  label: 'notSecret5',
+                  comment: 'notSecret6',
+                  content: { fr: { stringValue: 'B' } },
+                },
+                {
+                  id: 'nested3',
+                  label: 'notSecret7',
+                  comment: 'notSecret8',
+                  content: {
+                    fr: {
+                      compoundValue: [
+                        {
+                          id: 'deeplyNested',
+                          label: 'notSecret9',
+                          comment: 'notSecret10',
+                          content: { fr: { stringValue: 'C' } },
+                        },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      ],
+    }
+    const createdV6 = await apiV6.contactApi.createContactWithUser(
+      userV6,
+      await apiV6.contactApi.newInstance(userV6, patient, _.cloneDeep(contactData))
+    )
+    const createdV7 = await apiV7.contactApi.createContactWithUser(
+      userV7,
+      await apiV7.contactApi.newInstance(userV7, patient, _.cloneDeep(contactData))
+    )
+    ;[
+      await apiV6.contactApi.getContactWithUser(userV6, createdV7!.id!), // Read V7 from V6,
+      await apiV7.contactApi.getContactWithUser(userV7, createdV6.id), // Read V6 from V7
+    ].forEach((decrypted: any) => {
+      expect(decrypted.descr).to.equal(contactData.descr)
+      expect(decrypted.location).to.equal(contactData.location)
+      const flat = decrypted.services.find((s: any) => s.id === 'flat')
+      expect(flat.label).to.equal(contactData.services[0].label)
+      expect(flat.comment).to.equal(contactData.services[0].comment)
+      expect(flat.content).to.deep.equal(contactData.services[0].content)
+      const compound = decrypted.services.find((s: any) => s.id === 'compound')
+      expect(compound.label).to.equal(contactData.services[1].label)
+      expect(compound.comment).to.equal(contactData.services[1].comment)
+      const nested1 = compound.content.fr.compoundValue.find((s: any) => s.id === 'nested1')
+      expect(nested1.label).to.equal(contactData.services[1].content.fr.compoundValue![0].label)
+      expect(nested1.comment).to.equal(contactData.services[1].content.fr.compoundValue![0].comment)
+      expect(nested1.content).to.deep.equal(contactData.services[1].content.fr.compoundValue![0].content)
+      const nested2 = compound.content.fr.compoundValue.find((s: any) => s.id === 'nested2')
+      expect(nested2.label).to.equal(contactData.services[1].content.fr.compoundValue![1].label)
+      expect(nested2.comment).to.equal(contactData.services[1].content.fr.compoundValue![1].comment)
+      expect(nested2.content).to.deep.equal(contactData.services[1].content.fr.compoundValue![1].content)
+      const nested3 = compound.content.fr.compoundValue.find((s: any) => s.id === 'nested3')
+      expect(nested3.label).to.equal(contactData.services[1].content.fr.compoundValue![2].label)
+      expect(nested3.comment).to.equal(contactData.services[1].content.fr.compoundValue![2].comment)
+      const deeplyNested = nested3.content.fr.compoundValue.find((s: any) => s.id === 'deeplyNested')
+      expect(deeplyNested.label).to.equal(contactData.services[1].content.fr.compoundValue![2].content.fr.compoundValue![0].label)
+      expect(deeplyNested.comment).to.equal(contactData.services[1].content.fr.compoundValue![2].content.fr.compoundValue![0].comment)
+      expect(deeplyNested.content).to.deep.equal(contactData.services[1].content.fr.compoundValue![2].content.fr.compoundValue![0].content)
+    })
+    const encryptedV6 = await baseApi.getContact(createdV6.id)
+    const encryptedV7 = await baseApi.getContact(createdV7!.id!)
+    ;[encryptedV6, encryptedV7].forEach((encrypted: any) => {
+      expect(encrypted.descr).to.be.undefined
+      expect(encrypted.location).to.equal(contactData.location)
+      const flat = encrypted.services!.find((s: any) => s.id === 'flat')!
+      expect(flat.label).to.equal(contactData.services[0].label)
+      expect(flat.comment).to.equal(contactData.services[0].comment)
+      expect(Object.keys(flat.content ?? {})).to.have.length(0)
+      expect(flat.encryptedSelf).to.not.be.undefined
+      const compound = encrypted.services!.find((s: any) => s.id === 'compound')!
+      expect(compound.label).to.equal(contactData.services[1].label)
+      expect(compound.comment).to.equal(contactData.services[1].comment)
+      expect(compound.encryptedSelf).to.be.undefined
+      const nested1 = compound.content!.fr.compoundValue!.find((s: any) => s.id === 'nested1')!
+      expect(nested1.label).to.equal(contactData.services[1].content.fr.compoundValue![0].label)
+      expect(nested1.comment).to.equal(contactData.services[1].content.fr.compoundValue![0].comment)
+      expect(Object.keys(nested1.content ?? {})).to.have.length(0)
+      expect(nested1.encryptedSelf).to.not.be.undefined
+      const nested2 = compound.content!.fr.compoundValue!.find((s: any) => s.id === 'nested2')!
+      expect(nested2.label).to.equal(contactData.services[1].content.fr.compoundValue![1].label)
+      expect(nested2.comment).to.equal(contactData.services[1].content.fr.compoundValue![1].comment)
+      expect(Object.keys(nested2.content ?? {})).to.have.length(0)
+      expect(nested2.encryptedSelf).to.not.be.undefined
+      const nested3 = compound.content!.fr.compoundValue!.find((s: any) => s.id === 'nested3')!
+      expect(nested3.label).to.equal(contactData.services[1].content.fr.compoundValue![2].label)
+      expect(nested3.comment).to.equal(contactData.services[1].content.fr.compoundValue![2].comment)
+      expect(nested3.encryptedSelf).to.be.undefined
+      const deeplyNested = nested3.content!.fr.compoundValue!.find((s: any) => s.id === 'deeplyNested')!
+      expect(deeplyNested.label).to.equal(contactData.services[1].content.fr.compoundValue![2].content.fr.compoundValue![0].label)
+      expect(deeplyNested.comment).to.equal(contactData.services[1].content.fr.compoundValue![2].content.fr.compoundValue![0].comment)
+      expect(Object.keys(deeplyNested.content ?? {})).to.have.length(0)
+      expect(deeplyNested.encryptedSelf).to.not.be.undefined
+    })
+    expect(encryptedV6.encryptedSelf!.length).to.equal(encryptedV7.encryptedSelf!.length)
+  })
+
+  it('A HealthElement created from V6 should be readable from v7 and vice versa, and the structure of their encrypted data should be equivalent.', async () => {
+    const baseApi = new IccHelementApi(env.iCureUrl, {}, apiV7.authApi.authenticationProvider, fetch)
+    const healthElementData = {
+      note: 'secret',
+      descr: 'secret2',
+      idOpeningContact: 'notSecret',
+    }
+    const createdV6 = await apiV6.healthcareElementApi.createHealthElementWithUser(
+      userV6,
+      await apiV6.healthcareElementApi.newInstance(userV6, patient, _.cloneDeep(healthElementData))
+    )
+    const createdV7 = await apiV7.healthcareElementApi.createHealthElementWithUser(
+      userV7,
+      await apiV7.healthcareElementApi.newInstance(userV7, patient, _.cloneDeep(healthElementData))
+    )
+    ;[
+      await apiV6.healthcareElementApi.getHealthElementWithUser(userV6, createdV7.id), // Read V7 from V6,
+      await apiV7.healthcareElementApi.getHealthElementWithUser(userV7, createdV6.id), // Read V6 from V7
+    ].forEach((decrypted) => {
+      expect(decrypted.idOpeningContact).to.equal(healthElementData.idOpeningContact)
+      expect(decrypted.note).to.equal(healthElementData.note)
+      expect(decrypted.descr).to.equal(healthElementData.descr)
+    })
+    const encryptedV6 = await baseApi.getHealthElement(createdV6.id)
+    const encryptedV7 = await baseApi.getHealthElement(createdV7.id)
+    ;[encryptedV6, encryptedV7].forEach((encrypted) => {
+      expect(encrypted.idOpeningContact).to.equal(healthElementData.idOpeningContact)
+      expect(encrypted.note).to.be.undefined
+      expect(encrypted.descr).to.be.undefined
+      expect(encrypted.encryptedSelf).to.not.be.undefined
+    })
+    expect(encryptedV6.encryptedSelf!.length).to.equal(encryptedV7.encryptedSelf!.length)
+  })
+
+  it('A MaintenanceTask created from V6 should be readable from v7 and vice versa, and the structure of their encrypted data should be equivalent.', async () => {
+    const baseApi = new IccMaintenanceTaskApi(env.iCureUrl, {}, apiV7.authApi.authenticationProvider, fetch)
+    const maintenanceTaskData = {
+      taskType: 'notSecret',
+      properties: [
+        { id: 'test1', typedValue: { type: 'string', value: 'secret1' } },
+        { id: 'test2', typedValue: { type: 'string', value: 'secret2' } },
+      ],
+    }
+    const createdV6 = await apiV6.maintenanceTaskApi.createMaintenanceTaskWithUser(
+      userV6,
+      await apiV6.maintenanceTaskApi.newInstance(userV6, _.cloneDeep(maintenanceTaskData))
+    )
+    const createdV7 = await apiV7.maintenanceTaskApi.createMaintenanceTaskWithUser(
+      userV7,
+      await apiV7.maintenanceTaskApi.newInstance(userV7, _.cloneDeep(maintenanceTaskData))
+    )
+    ;[
+      await apiV6.maintenanceTaskApi.getMaintenanceTaskWithUser(userV6, createdV7!.id!), // Read V7 from V6,
+      await apiV7.maintenanceTaskApi.getMaintenanceTaskWithUser(userV7, createdV6.id), // Read V6 from V7
+    ].forEach((decrypted) => {
+      expect(decrypted.taskType).to.equal(maintenanceTaskData.taskType)
+      ;['test1', 'test2'].forEach((propId) => {
+        const prop = decrypted.properties!.find((p: any) => p.id === propId)
+        const ogProp = maintenanceTaskData.properties!.find((p) => p.id === propId)
+        expect(prop).to.not.be.undefined
+        expect(prop!.typedValue).to.deep.equal(ogProp!.typedValue)
+      })
+    })
+    const encryptedV6 = await baseApi.getMaintenanceTask(createdV6.id)
+    const encryptedV7 = await baseApi.getMaintenanceTask(createdV7!.id!)
+    ;[encryptedV6, encryptedV7].forEach((encrypted) => {
+      expect(encrypted.taskType).to.equal(maintenanceTaskData.taskType)
+      expect(encrypted.properties ?? []).to.have.length(0)
+      expect(encrypted.encryptedSelf).to.not.be.undefined
+    })
+    expect(encryptedV6.encryptedSelf!.length).to.equal(encryptedV7.encryptedSelf!.length)
+  })
+
+  it('A Patient created from V6 should be readable from v7 and vice versa, and the structure of their encrypted data should be equivalent.', async () => {
+    const baseApi = new IccPatientApi(env.iCureUrl, {}, apiV7.authApi.authenticationProvider, fetch)
+    const patientData = {
+      firstName: 'John',
+      lastName: 'Doe',
+      note: 'This is a note',
+      properties: [
+        { id: 'test1', typedValue: { type: 'string', value: 'test1' } },
+        { id: 'test2', typedValue: { type: 'string', value: 'test2' } },
+      ],
+    }
+    const createdV6 = await apiV6.patientApi.createPatientWithUser(userV6, await apiV6.patientApi.newInstance(userV6, _.cloneDeep(patientData)))
+    const createdV7 = await apiV7.patientApi.createPatientWithUser(userV7, await apiV7.patientApi.newInstance(userV7, _.cloneDeep(patientData)))
+    ;[
+      await apiV6.patientApi.getPatientWithUser(userV6, createdV7.id), // Read V7 from V6,
+      await apiV7.patientApi.getPatientWithUser(userV7, createdV6.id), // Read V6 from V7
+    ].forEach((decrypted) => {
+      expect(decrypted.firstName).to.equal(patientData.firstName)
+      expect(decrypted.lastName).to.equal(patientData.lastName)
+      expect(decrypted.note).to.equal(patientData.note)
+      expect(decrypted.properties ?? []).to.have.length(2)
+      ;['test1', 'test2'].forEach((propId) => {
+        const prop = decrypted.properties!.find((p: any) => p.id === propId)
+        const ogProp = patientData.properties!.find((p) => p.id === propId)
+        expect(prop).to.not.be.undefined
+        expect(prop!.typedValue).to.deep.equal(ogProp!.typedValue)
+      })
+    })
+    const encryptedV6 = await baseApi.getPatient(createdV6.id)
+    const encryptedV7 = await baseApi.getPatient(createdV7.id)
+    ;[encryptedV6, encryptedV7].forEach((encrypted) => {
+      expect(encrypted.firstName).to.equal(patientData.firstName)
+      expect(encrypted.lastName).to.equal(patientData.lastName)
+      expect(encrypted.note).to.be.undefined
+      expect(encrypted.encryptedSelf).to.not.be.undefined
+      expect(encrypted.properties ?? []).to.have.length(2)
+      ;['test1', 'test2'].forEach((propId) => {
+        const prop = encrypted.properties!.find((p) => p.id === propId)
+        expect(prop).to.not.be.undefined
+        expect(prop!.typedValue).to.be.undefined
+        expect(prop!.encryptedSelf).to.not.be.undefined
+      })
+    })
+    expect(encryptedV6.encryptedSelf!.length).to.equal(encryptedV7.encryptedSelf!.length)
+    ;['test1', 'test2'].forEach((propId) => {
+      expect(encryptedV6.properties!.find((p) => p.id === propId)!.encryptedSelf!.length).to.equal(
+        encryptedV7.properties!.find((p) => p.id === propId)!.encryptedSelf!.length
+      )
+    })
+  })
+})

--- a/test/icc-x-api/icc-contact-x-api.ts
+++ b/test/icc-x-api/icc-contact-x-api.ts
@@ -246,4 +246,8 @@ describe('icc-x-contact-api Tests', () => {
     expect(retrieved.services![0].content).deep.equals(entity.services![0].content)
     expect((await api2.contactApi.decryptPatientIdOf(retrieved))[0]).to.equal(samplePatient.id)
   })
+
+  it('Custom service encryption fields should be applied recursively on compound services', async () => {
+    throw new Error('Not implemented yet')
+  })
 })

--- a/test/icc-x-api/utils/crypto-utils-test.ts
+++ b/test/icc-x-api/utils/crypto-utils-test.ts
@@ -1,0 +1,642 @@
+import { crypt, decrypt, EncryptedFieldsKeys, parseEncryptedFields, ua2utf8, utf8_2ua } from '../../../icc-x-api'
+import * as _ from 'lodash'
+import { expect } from 'chai'
+
+describe('Crypt / decrypt', () => {
+  it('encrypted fields parsing should create the appropriate structure', () => {
+    const fields = [
+      'field1',
+      'field2',
+      'nestedField.field3',
+      'nestedField.field4',
+      'arrayField[].field5',
+      'arrayField[].field6',
+      'arrayField[].nestedField.field7',
+      'arrayField2[].' +
+        JSON.stringify(['field8', 'mapField.*.field9', 'nestedField.' + JSON.stringify(['field10', 'field11']), 'nestedField.field12']),
+      'mapField.*.field13',
+      'mapField.*.field14',
+    ]
+    const parsedFields = parseEncryptedFields(fields, 'Test.')
+    function checkParsedFields(
+      fields: EncryptedFieldsKeys,
+      expectedTopLevelFields: { fieldName: string; fieldPath: string }[],
+      expectedNestedFields: { [name: string]: (subkeys: EncryptedFieldsKeys) => void },
+      expectedArrayFields: { [name: string]: (subkeys: EncryptedFieldsKeys) => void },
+      expectedMapFields: { [name: string]: (subkeys: EncryptedFieldsKeys) => void }
+    ) {
+      expect(fields.topLevelFields.map((x) => JSON.stringify(x))).to.have.members(expectedTopLevelFields.map((x) => JSON.stringify(x)))
+      expect(Object.keys(fields.nestedObjectsKeys)).to.have.members(Object.keys(expectedNestedFields))
+      expect(Object.keys(fields.arraysValuesKeys)).to.have.members(Object.keys(expectedArrayFields))
+      expect(Object.keys(fields.mapsValuesKeys)).to.have.members(Object.keys(expectedMapFields))
+      for (const [k, v] of Object.entries(expectedNestedFields)) {
+        v(fields.nestedObjectsKeys[k])
+      }
+      for (const [k, v] of Object.entries(expectedArrayFields)) {
+        v(fields.arraysValuesKeys[k])
+      }
+      for (const [k, v] of Object.entries(expectedMapFields)) {
+        v(fields.mapsValuesKeys[k])
+      }
+    }
+    checkParsedFields(
+      parsedFields,
+      [
+        { fieldName: 'field1', fieldPath: 'Test.field1' },
+        { fieldName: 'field2', fieldPath: 'Test.field2' },
+      ],
+      {
+        nestedField: (x) =>
+          checkParsedFields(
+            x,
+            [
+              { fieldName: 'field3', fieldPath: 'Test.nestedField.field3' },
+              { fieldName: 'field4', fieldPath: 'Test.nestedField.field4' },
+            ],
+            {},
+            {},
+            {}
+          ),
+      },
+      {
+        arrayField: (x) =>
+          checkParsedFields(
+            x,
+            [
+              { fieldName: 'field5', fieldPath: 'Test.arrayField[].field5' },
+              { fieldName: 'field6', fieldPath: 'Test.arrayField[].field6' },
+            ],
+            {
+              nestedField: (x) => checkParsedFields(x, [{ fieldName: 'field7', fieldPath: 'Test.arrayField[].nestedField.field7' }], {}, {}, {}),
+            },
+            {},
+            {}
+          ),
+        arrayField2: (x) =>
+          checkParsedFields(
+            x,
+            [{ fieldName: 'field8', fieldPath: 'Test.arrayField2[].field8' }],
+            {
+              nestedField: (x) =>
+                checkParsedFields(
+                  x,
+                  [
+                    { fieldName: 'field10', fieldPath: 'Test.arrayField2[].nestedField.field10' },
+                    { fieldName: 'field11', fieldPath: 'Test.arrayField2[].nestedField.field11' },
+                    { fieldName: 'field12', fieldPath: 'Test.arrayField2[].nestedField.field12' },
+                  ],
+                  {},
+                  {},
+                  {}
+                ),
+            },
+            {},
+            {
+              mapField: (x) => checkParsedFields(x, [{ fieldName: 'field9', fieldPath: 'Test.arrayField2[].mapField.*.field9' }], {}, {}, {}),
+            }
+          ),
+      },
+      {
+        mapField: (x) =>
+          checkParsedFields(
+            x,
+            [
+              { fieldName: 'field13', fieldPath: 'Test.mapField.*.field13' },
+              { fieldName: 'field14', fieldPath: 'Test.mapField.*.field14' },
+            ],
+            {},
+            {},
+            {}
+          ),
+      }
+    )
+  })
+
+  it('encrypted fields parsing should fail in case of any field being invalid', () => {
+    const sampleValidFields = [
+      'field1',
+      'nestedField.field3',
+      'arrayField[].nestedField.field7',
+      'arrayField2[].' + JSON.stringify(['field8', 'mapField.*.field9']),
+      'mapField.*.field13',
+    ]
+    const invalidFields: [string, string | null][] = [
+      ['a.1b', null],
+      ['a.[].b', null],
+      ['a[].*.b', null], // Not supported but maybe in future
+      ['a[].b.{}', null],
+      ['a[].b.["c", 0]', null],
+      ['a.*.b.["c", "\\"]', null],
+      ['a[].b.["c", "1notAField"]', 'a[].b.1notAField'],
+      ['a.b.' + JSON.stringify(['c', 'd.*.' + JSON.stringify(['e', 'f[].' + JSON.stringify(['g', '1notAField'])])]), 'a.b.d.*.f[].1notAField'],
+    ]
+    for (const [field, expectedErrorMessageInfo] of invalidFields) {
+      let result: EncryptedFieldsKeys | undefined = undefined
+      try {
+        result = parseEncryptedFields([...sampleValidFields, field], 'Test.')
+      } catch (e) {
+        expect(e).to.be.instanceOf(Error)
+        expect((e as Error).message).to.include('Test.' + (expectedErrorMessageInfo ?? field))
+      }
+      expect(result, 'Operation should fail for field: ' + field).to.be.undefined
+    }
+  })
+
+  const sampleObj = {
+    field1: 'nonEncryptedValue1A',
+    field2: 'nonEncryptedValue2A',
+    field3: 'encryptedValue3A',
+    field4: 'encryptedValue4A',
+    nestedData: {
+      field1: 'nonEncryptedValue1B',
+      field2: 'encryptedValue2B',
+      field3: 'nonEncryptedValue3B',
+      field4: 'encryptedValue4B',
+    },
+    arrayData: [
+      {
+        field1: 'nonEncryptedValue1C',
+        field2: 'encryptedValue2C',
+        field3: 'encryptedValue3C',
+        field4: 'nonEncryptedValue4C',
+        nestedData: {
+          field1: 'encryptedValue1D',
+          field2: 'encryptedValue2D',
+          field3: 'nonEncryptedValue3D',
+          field4: 'nonEncryptedValue4D',
+        },
+        arrayData: [
+          {
+            field1: 'encryptedValue1E',
+            field2: 'nonEncryptedValue2E',
+            field3: 'nonEncryptedValue3E',
+            field4: 'encryptedValue4E',
+            arrayData: [
+              null,
+              {
+                a: 1, // encrypted
+                b: 2, // encrypted
+                x: 3,
+                y: 4,
+              },
+            ],
+          },
+          {
+            field1: 'encryptedValue1F',
+            field2: 'nonEncryptedValue2F',
+            field3: 'nonEncryptedValue3F',
+            field4: 'encryptedValue4F',
+            nestedData: {
+              a: 1,
+              b: 2,
+              x: 3, // encrypted
+              y: 4, // encrypted
+            },
+            // No array data: by convention we usually considered undefined array as empty, but in future this may change. The crypt/decrypt must
+            // handle this properly
+          },
+        ],
+      },
+      null, // Should be left as null
+      {
+        field1: 'nonEncryptedValue1G',
+        field2: 'encryptedValue2G',
+        field3: 'encryptedValue3G',
+        field4: 'nonEncryptedValue4G',
+        nestedData: {
+          field1: 'encryptedValue1H',
+          field2: 'encryptedValue2H',
+          field3: 'nonEncryptedValue3H',
+          field4: 'nonEncryptedValue4H',
+        },
+        arrayData: [],
+      },
+    ],
+    arrayData2: [
+      {
+        field1: 'encryptedValue1I',
+        field2: 'nonEncryptedValue2I',
+        field3: 'nonEncryptedValue3I',
+        field4: 'encryptedValue4I',
+      },
+      {
+        field1: 'encryptedValue1J',
+        field2: 'nonEncryptedValue2J',
+        field3: 'nonEncryptedValue3J',
+        field4: 'encryptedValue4J',
+      },
+    ],
+    mapData: {
+      a: {
+        field2: 'encryptedValue2K',
+        field4: 'nonEncryptedValue4K',
+      },
+      b: {
+        field1: 'nonEncryptedValue1L',
+        field3: 'encryptedValue3L',
+      },
+      c: {
+        field1: 'nonEncryptedValue1M',
+        field2: 'encryptedValue2M',
+        field3: 'encryptedValue3M',
+        field4: 'nonEncryptedValue4M',
+      },
+      d: {
+        field1: 'nonEncryptedValue1N',
+        field4: 'nonEncryptedValue4N',
+        // If the encrypted fields are all optional and missing the encrypted self should still be set (from {})
+      },
+    },
+  }
+
+  const sampleObjEncryptionKeys = [
+    'field3',
+    'field4',
+    'nestedData.field2',
+    'nestedData.field4',
+    'arrayData[].' +
+      JSON.stringify([
+        'field2',
+        'field3',
+        'nestedData.field1',
+        'nestedData.field2',
+        'arrayData[].' + JSON.stringify(['field1', 'field4', 'nestedData.x', 'nestedData.y', 'arrayData[].' + JSON.stringify(['a', 'b'])]),
+      ]),
+    'arrayData2[].field1',
+    'arrayData2[].field4',
+    'mapData.*.field2',
+    'mapData.*.field3',
+  ]
+
+  it('crypt should not modify input object (should create shallow copy as needed)', async () => {
+    const toBeCrypted = _.cloneDeep(sampleObj)
+    const crypted = await crypt(
+      toBeCrypted,
+      async () => {
+        return utf8_2ua('Test')
+      },
+      parseEncryptedFields(sampleObjEncryptionKeys, 'TestObj.'),
+      'testObj'
+    )
+    expect(crypted).to.not.deep.equal(toBeCrypted)
+    expect(toBeCrypted).to.deep.equal(sampleObj)
+  })
+
+  it('encrypted object should delete encrypted fields and set encryptedSelf', async () => {
+    const encryptedSelf = 'VGVzdA=='
+    const expectedEncrypted = {
+      field1: 'nonEncryptedValue1A',
+      field2: 'nonEncryptedValue2A',
+      encryptedSelf,
+      nestedData: {
+        field1: 'nonEncryptedValue1B',
+        field3: 'nonEncryptedValue3B',
+        encryptedSelf,
+      },
+      arrayData: [
+        {
+          field1: 'nonEncryptedValue1C',
+          field4: 'nonEncryptedValue4C',
+          encryptedSelf,
+          nestedData: {
+            field3: 'nonEncryptedValue3D',
+            field4: 'nonEncryptedValue4D',
+            encryptedSelf,
+          },
+          arrayData: [
+            {
+              field2: 'nonEncryptedValue2E',
+              field3: 'nonEncryptedValue3E',
+              encryptedSelf,
+              arrayData: [
+                null,
+                {
+                  x: 3,
+                  y: 4,
+                  encryptedSelf,
+                },
+              ],
+            },
+            {
+              field2: 'nonEncryptedValue2F',
+              field3: 'nonEncryptedValue3F',
+              encryptedSelf,
+              nestedData: {
+                a: 1,
+                b: 2,
+                encryptedSelf,
+              },
+              // No array data: by convention we usually considered undefined array as empty, but in future this may change. The crypt/decrypt must
+              // handle this properly
+            },
+          ],
+        },
+        null,
+        {
+          field1: 'nonEncryptedValue1G',
+          field4: 'nonEncryptedValue4G',
+          encryptedSelf,
+          nestedData: {
+            field3: 'nonEncryptedValue3H',
+            field4: 'nonEncryptedValue4H',
+            encryptedSelf,
+          },
+          arrayData: [],
+        },
+      ],
+      arrayData2: [
+        {
+          field2: 'nonEncryptedValue2I',
+          field3: 'nonEncryptedValue3I',
+          encryptedSelf,
+        },
+        {
+          field2: 'nonEncryptedValue2J',
+          field3: 'nonEncryptedValue3J',
+          encryptedSelf,
+        },
+      ],
+      mapData: {
+        a: {
+          field4: 'nonEncryptedValue4K',
+          encryptedSelf,
+        },
+        b: {
+          field1: 'nonEncryptedValue1L',
+          encryptedSelf,
+        },
+        c: {
+          field1: 'nonEncryptedValue1M',
+          field4: 'nonEncryptedValue4M',
+          encryptedSelf,
+        },
+        d: {
+          field1: 'nonEncryptedValue1N',
+          field4: 'nonEncryptedValue4N',
+          encryptedSelf,
+        },
+      },
+    }
+    const encryptedObj = await crypt(
+      sampleObj,
+      async () => {
+        return utf8_2ua('Test')
+      },
+      parseEncryptedFields(sampleObjEncryptionKeys, 'TestObj.'),
+      'testObj'
+    )
+    expect(encryptedObj).to.deep.equal(expectedEncrypted)
+  })
+
+  it('encrypted then decrypted object should equal the original', async () => {
+    const encryptedObj = await crypt(
+      sampleObj,
+      async (obj: { [key: string]: string }) => {
+        return utf8_2ua(JSON.stringify(obj))
+      },
+      parseEncryptedFields(sampleObjEncryptionKeys, 'TestObj.'),
+      'testObj.'
+    )
+    const decryptedObj = await decrypt(encryptedObj, async (obj: Uint8Array) => {
+      return JSON.parse(ua2utf8(obj))
+    })
+    expect(encryptedObj).to.not.deep.equal(sampleObj)
+    expect(decryptedObj).to.deep.equal(sampleObj)
+  })
+
+  it('crypt should verify the type of fields matches what is defined by the encrypted fields keys', async () => {
+    const cases: { keys: EncryptedFieldsKeys; obj: { [k: string]: any }; brokenField: string }[] = [
+      {
+        keys: {
+          topLevelFields: [],
+          nestedObjectsKeys: {
+            shouldBeObject: {
+              topLevelFields: [],
+              nestedObjectsKeys: {
+                nestedShouldBeObject: {
+                  topLevelFields: [{ fieldName: 'field1', fieldPath: 'shouldBeObject.nestedShouldBeObject.field1' }],
+                  nestedObjectsKeys: {},
+                  mapsValuesKeys: {},
+                  arraysValuesKeys: {},
+                },
+              },
+              mapsValuesKeys: {},
+              arraysValuesKeys: {},
+            },
+          },
+          mapsValuesKeys: {},
+          arraysValuesKeys: {},
+        },
+        obj: {
+          shouldBeObject: {
+            nestedShouldBeObject: 'not an object',
+          },
+        },
+        brokenField: 'shouldBeObject.nestedShouldBeObject',
+      },
+      {
+        keys: {
+          topLevelFields: [],
+          nestedObjectsKeys: {
+            shouldBeObject: {
+              topLevelFields: [],
+              nestedObjectsKeys: {
+                nestedShouldBeObject: {
+                  topLevelFields: [{ fieldName: 'field1', fieldPath: 'shouldBeObject.nestedShouldBeObject.field1' }],
+                  nestedObjectsKeys: {},
+                  mapsValuesKeys: {},
+                  arraysValuesKeys: {},
+                },
+              },
+              mapsValuesKeys: {},
+              arraysValuesKeys: {},
+            },
+          },
+          mapsValuesKeys: {},
+          arraysValuesKeys: {},
+        },
+        obj: {
+          shouldBeObject: 'not an object',
+        },
+        brokenField: 'shouldBeObject',
+      },
+      {
+        keys: {
+          topLevelFields: [],
+          nestedObjectsKeys: {
+            shouldBeObject: {
+              topLevelFields: [{ fieldName: 'field1', fieldPath: 'shouldBeObject.field1' }],
+              nestedObjectsKeys: {},
+              mapsValuesKeys: {},
+              arraysValuesKeys: {},
+            },
+          },
+          mapsValuesKeys: {},
+          arraysValuesKeys: {},
+        },
+        obj: {
+          shouldBeObject: [{ field1: 'something' }],
+        },
+        brokenField: 'shouldBeObject',
+      },
+      {
+        keys: {
+          topLevelFields: [],
+          nestedObjectsKeys: {},
+          mapsValuesKeys: {
+            shouldBeMap: {
+              topLevelFields: [{ fieldName: 'field1', fieldPath: 'shouldBeMap.*.field1' }],
+              nestedObjectsKeys: {},
+              mapsValuesKeys: {},
+              arraysValuesKeys: {},
+            },
+          },
+          arraysValuesKeys: {},
+        },
+        obj: {
+          shouldBeMap: {
+            key1: { field1: 'something' },
+            key2: 'not an object',
+          },
+        },
+        brokenField: 'shouldBeMap.key2',
+      },
+      {
+        keys: {
+          topLevelFields: [],
+          nestedObjectsKeys: {},
+          mapsValuesKeys: {
+            shouldBeMap: {
+              topLevelFields: [{ fieldName: 'field1', fieldPath: 'shouldBeMap.*.field1' }],
+              nestedObjectsKeys: {},
+              mapsValuesKeys: {},
+              arraysValuesKeys: {},
+            },
+          },
+          arraysValuesKeys: {},
+        },
+        obj: {
+          shouldBeMap: {
+            key1: [],
+          },
+        },
+        brokenField: 'shouldBeMap.key1',
+      },
+      {
+        keys: {
+          topLevelFields: [],
+          nestedObjectsKeys: {},
+          mapsValuesKeys: {
+            shouldBeMap: {
+              topLevelFields: [{ fieldName: 'field1', fieldPath: 'shouldBeMap.*.field1' }],
+              nestedObjectsKeys: {},
+              mapsValuesKeys: {},
+              arraysValuesKeys: {},
+            },
+          },
+          arraysValuesKeys: {},
+        },
+        obj: {
+          shouldBeMap: [],
+        },
+        brokenField: 'shouldBeMap',
+      },
+      {
+        keys: {
+          topLevelFields: [],
+          nestedObjectsKeys: {},
+          mapsValuesKeys: {
+            shouldBeMap: {
+              topLevelFields: [{ fieldName: 'field1', fieldPath: 'shouldBeMap.*.field1' }],
+              nestedObjectsKeys: {},
+              mapsValuesKeys: {},
+              arraysValuesKeys: {},
+            },
+          },
+          arraysValuesKeys: {},
+        },
+        obj: {
+          shouldBeMap: 'not a map',
+        },
+        brokenField: 'shouldBeMap',
+      },
+      {
+        keys: {
+          topLevelFields: [],
+          nestedObjectsKeys: {},
+          mapsValuesKeys: {},
+          arraysValuesKeys: {
+            shouldBeArray: {
+              topLevelFields: [{ fieldName: 'field1', fieldPath: 'shouldBeArray[].field1' }],
+              nestedObjectsKeys: {},
+              mapsValuesKeys: {},
+              arraysValuesKeys: {},
+            },
+          },
+        },
+        obj: {
+          shouldBeArray: {
+            0: { field1: 'fake array' },
+            1: { field1: 'wow' },
+          },
+        },
+        brokenField: 'shouldBeArray',
+      },
+      {
+        keys: {
+          topLevelFields: [],
+          nestedObjectsKeys: {},
+          mapsValuesKeys: {},
+          arraysValuesKeys: {
+            shouldBeArray: {
+              topLevelFields: [{ fieldName: 'field1', fieldPath: 'shouldBeArray[].field1' }],
+              nestedObjectsKeys: {},
+              mapsValuesKeys: {},
+              arraysValuesKeys: {},
+            },
+          },
+        },
+        obj: {
+          shouldBeArray: [{ field1: 'this is ok' }, 'this is not ok'],
+        },
+        brokenField: 'shouldBeArray[1]',
+      },
+    ]
+    for (const c of cases) {
+      let success = false
+      try {
+        await crypt(
+          c.obj,
+          async (obj: { [key: string]: string }) => {
+            return utf8_2ua(JSON.stringify(obj))
+          },
+          c.keys,
+          'testObj'
+        )
+        success = true
+      } catch (e) {
+        expect(e).to.be.instanceOf(Error)
+        console.log((e as Error).message)
+        expect((e as Error).message).to.include(` testObj.${c.brokenField} `)
+      }
+      expect(success, 'Crypt should fail').to.be.false
+    }
+  })
+
+  it('decrypt should not break arrays of primitive values', async function () {
+    const cases = [
+      { array: ['abc', 'bcd', 'cde'] },
+      { array: [1, 2, 3] },
+      { array: [true, false, true] },
+      { array: [null, null, null] },
+      { array: [undefined, undefined, undefined] },
+      { array: [BigInt(1), BigInt(2), BigInt(3)] },
+    ]
+    for (const c of cases) {
+      const decrypted = await decrypt(c, () => {
+        throw new Error('Should not actually be needed for this test')
+      })
+      expect(decrypted).to.deep.equal(c)
+    }
+  })
+})

--- a/test/icc-x-api/utils/crypto-utils-test.ts
+++ b/test/icc-x-api/utils/crypto-utils-test.ts
@@ -388,7 +388,7 @@ describe('Crypt / decrypt', () => {
     expect(encryptedObj).to.deep.equal(expectedEncrypted)
   })
 
-  it('encrypted then decrypted object should equal the original', async () => {
+  it('encrypted then decrypted object should equal the original (excluding for the addition of encrypted self)', async () => {
     const encryptedObj = await crypt(
       sampleObj,
       async (obj: { [key: string]: string }) => {
@@ -400,8 +400,12 @@ describe('Crypt / decrypt', () => {
     const decryptedObj = await decrypt(encryptedObj, async (obj: Uint8Array) => {
       return JSON.parse(ua2utf8(obj))
     })
-    expect(encryptedObj).to.not.deep.equal(sampleObj)
-    expect(decryptedObj).to.deep.equal(sampleObj)
+    const stripEncryptedSelf = (obj: any) =>
+      _.cloneDeepWith(_.cloneDeep(obj), (v) => {
+        if (v !== null && typeof v == 'object') delete v['encryptedSelf']
+      })
+    expect(stripEncryptedSelf(encryptedObj)).to.not.deep.equal(sampleObj)
+    expect(stripEncryptedSelf(decryptedObj)).to.deep.equal(sampleObj)
   })
 
   it('crypt should verify the type of fields matches what is defined by the encrypted fields keys', async () => {

--- a/test/utils/test_utils.ts
+++ b/test/utils/test_utils.ts
@@ -55,7 +55,7 @@ export async function getEnvironmentInitializer(): Promise<EnvInitializer> {
 }
 
 export namespace TestUtils {
-  export async function initApi(envVars: TestVars, userName: string = hcp1Username): Promise<Apis> {
+  export async function initApi(envVars: TestVars, userName: string = hcp1Username): Promise<IcureApi> {
     return await getApiAndAddPrivateKeysForUser(envVars.iCureUrl, envVars.dataOwnerDetails[userName])
   }
 


### PR DESCRIPTION
- New syntax for the customization of encrypted fields:
  - Choose encrypted fields for nested objects with `.`
  - Choose encryption fields for all objects in an array with `[].` (the values must be objects)
  - Choose encryption fields for all values of a map with `.*.` (the values must be objects)
  - Does not yet support encrypted fields like `arrayOfArrays[][].value` or `arrayOfMaps[].*.`. There must always be an object between an array/map and another array/map. This use case should not be needed with the current data model
- Support for customization of Contact and Service encrypted fields. The encryption of the `content` of a Service is not customizable
  - Important: the use of custom encryption fields for `Service` breaks full-data compatibility with v6: if there are custom fields compound services created with v7 won't be decrypted properly from v6